### PR TITLE
Configure Dependabot daily updates with release age guard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,54 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "03:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    allow:
+      - dependency-type: "direct"
+  - package-ecosystem: "npm"
+    directory: "/client"
+    schedule:
+      interval: "daily"
+      time: "03:30"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    allow:
+      - dependency-type: "direct"
+  - package-ecosystem: "npm"
+    directory: "/server"
+    schedule:
+      interval: "daily"
+      time: "04:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    allow:
+      - dependency-type: "direct"
+  - package-ecosystem: "npm"
+    directory: "/shared"
+    schedule:
+      interval: "daily"
+      time: "04:30"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    allow:
+      - dependency-type: "direct"
+  - package-ecosystem: "npm"
+    directory: "/core"
+    schedule:
+      interval: "daily"
+      time: "05:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    allow:
+      - dependency-type: "direct"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "05:30"
+      timezone: "UTC"
+    open-pull-requests-limit: 10

--- a/.github/workflows/dependabot-age.yml
+++ b/.github/workflows/dependabot-age.yml
@@ -1,0 +1,34 @@
+name: "Dependabot release age guard"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  enforce-age:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+      - name: Setup Node.js
+        if: ${{ steps.metadata.outputs.package-ecosystem == 'npm' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Ensure dependency releases are at least three days old
+        if: ${{ steps.metadata.outputs.package-ecosystem == 'npm' }}
+        run: node scripts/dependabot-release-age-check.mjs
+        env:
+          UPDATED_DEPENDENCIES_JSON: ${{ steps.metadata.outputs.updated-dependencies-json }}
+          MIN_RELEASE_AGE_DAYS: 3

--- a/scripts/dependabot-release-age-check.mjs
+++ b/scripts/dependabot-release-age-check.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+
+const dependenciesJson = process.env.UPDATED_DEPENDENCIES_JSON;
+const minReleaseAgeDays = Number.parseInt(process.env.MIN_RELEASE_AGE_DAYS || '3', 10);
+const registryBaseUrl = (process.env.NPM_REGISTRY_URL || 'https://registry.npmjs.org').replace(/\/$/, '');
+const registryAuthToken = process.env.NPM_REGISTRY_TOKEN || process.env.NODE_AUTH_TOKEN;
+
+if (!dependenciesJson) {
+    console.log('No updated dependencies metadata provided; skipping age verification.');
+    process.exit(0);
+}
+
+let dependencies;
+try {
+    dependencies = JSON.parse(dependenciesJson);
+} catch (error) {
+    console.error('Unable to parse Dependabot metadata payload:', error);
+    process.exit(1);
+}
+
+if (!Array.isArray(dependencies) || dependencies.length === 0) {
+    console.log('Metadata does not include dependency entries; nothing to check.');
+    process.exit(0);
+}
+
+const now = new Date();
+const failures = [];
+
+const packagesToCheck = new Map();
+
+for (const dependency of dependencies) {
+    const name = dependency?.dependencyName;
+    const ecosystem = dependency?.packageEcosystem ?? '';
+    const version = dependency?.newVersion;
+
+    if (!name || !version) {
+        continue;
+    }
+
+    if (ecosystem && ecosystem !== 'npm' && ecosystem !== 'yarn' && ecosystem !== 'pnpm') {
+        console.log(`Skipping ${name}@${version} from unsupported ecosystem '${ecosystem}'.`);
+        continue;
+    }
+
+    if (!packagesToCheck.has(name)) {
+        packagesToCheck.set(name, new Set());
+    }
+
+    packagesToCheck.get(name).add(version);
+}
+
+if (packagesToCheck.size === 0) {
+    console.log('No npm dependencies require release age verification.');
+    process.exit(0);
+}
+
+async function fetchReleaseTimestamps(packageName) {
+    const encodedName = encodeURIComponent(packageName);
+    const response = await fetch(`${registryBaseUrl}/${encodedName}`, {
+        headers: {
+            accept: 'application/vnd.npm.install-v1+json',
+            ...(registryAuthToken ? {authorization: `Bearer ${registryAuthToken}`} : {}),
+        },
+    });
+
+    if (!response.ok) {
+        throw new Error(`registry responded with ${response.status} ${response.statusText}`);
+    }
+
+    const body = await response.json();
+    const timestamps = body?.time;
+
+    if (!timestamps || typeof timestamps !== 'object') {
+        throw new Error('registry response did not include release timestamps');
+    }
+
+    return timestamps;
+}
+
+async function verifyDependencies() {
+    for (const [name, versions] of packagesToCheck) {
+        let timestamps;
+        try {
+            timestamps = await fetchReleaseTimestamps(name);
+        } catch (error) {
+            for (const version of versions) {
+                failures.push(`Unable to retrieve release information for ${name}@${version}: ${error.message}`);
+            }
+            continue;
+        }
+
+        for (const version of versions) {
+            const timestamp = timestamps?.[version];
+            if (!timestamp) {
+                failures.push(`Release timestamp for ${name}@${version} was not found.`);
+                continue;
+            }
+
+            const releasedAt = new Date(timestamp);
+            if (Number.isNaN(releasedAt.valueOf())) {
+                failures.push(`Release timestamp for ${name}@${version} is invalid: ${timestamp}`);
+                continue;
+            }
+
+            const ageMs = now.getTime() - releasedAt.getTime();
+            const ageDays = ageMs / (1000 * 60 * 60 * 24);
+
+            console.log(`${name}@${version} was released ${ageDays.toFixed(2)} days ago.`);
+
+            if (ageDays < minReleaseAgeDays) {
+                failures.push(`${name}@${version} is only ${ageDays.toFixed(2)} days old (minimum required: ${minReleaseAgeDays}).`);
+            }
+        }
+    }
+
+    if (failures.length > 0) {
+        console.error('Dependency age verification failed:');
+        for (const message of failures) {
+            console.error(` - ${message}`);
+        }
+        process.exit(1);
+    }
+
+    console.log(`All dependencies satisfy the minimum release age of ${minReleaseAgeDays} days.`);
+}
+
+try {
+    await verifyDependencies();
+} catch (error) {
+    console.error('Unexpected error verifying dependency release age:', error);
+    process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add a Dependabot configuration that checks each workspace and GitHub Actions daily
- introduce a workflow that verifies Dependabot npm updates are at least three days old
- update the release age guard script to query the npm registry API directly while enforcing the three-day minimum

## Testing
- bun install
- bun run test

------
https://chatgpt.com/codex/tasks/task_e_68e7fa0674c88329abc100824d0766fc