### PR TITLE
Remove frozen lockfile flag from CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           bun-version: '1.2.4'
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install
 
       - name: Run tests with coverage thresholds
         run: bun run test


### PR DESCRIPTION
## Summary
- update the CI workflow to install dependencies without the --frozen-lockfile flag before running tests

## Testing
- bun run test

------
https://chatgpt.com/codex/tasks/task_e_68e808d6f688832997a414f0eecf9578