### PR TITLE
Refactor attempts API to use project-based routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,13 +184,14 @@ or the nested alias `/projects/:projectId/board/*`.
   `GET /projects/:projectId/github/origin`
 - Boards: `GET /boards/:boardId`, `POST /boards/:boardId/cards`, `PATCH /boards/:boardId/cards/:cardId`
   (content updates, dependency changes, and card moves), `DELETE /boards/:boardId/cards/:cardId`,
-  `POST /boards/:boardId/import/github/issues`, `POST /boards/:boardId/cards/:cardId/attempts`
+  `POST /boards/:boardId/import/github/issues` (board-scoped attempt creation is deprecated; use the project route below)
 - Card moves now piggyback on the `PATCH /boards/:boardId/cards/:cardId` endpoint by supplying both `columnId`
   and `index`; successful moves respond with the patched card plus updated column snapshots so the client can
   update the local board state without a refetch.
-- Attempts: `POST /attempts/boards/:boardId/cards/:cardId/attempts`, `GET /attempts/:id`, `POST /attempts/:id/stop`,
-  `GET /attempts/:id/logs` (`POST /attempts/:id/stop` now force-stops attempts stuck in running/queued states even if
-  the worker process is no longer tracked)
+- Attempts: `POST /projects/:projectId/cards/:cardId/attempts` (canonical), `GET /projects/:projectId/cards/:cardId/attempt`
+  for latest attempt + logs/messages, `GET /attempts/:id`, `PATCH /attempts/:id` with `{status:"stopped"}` to stop,
+  `POST /attempts/:id/messages` for follow-ups, `GET /attempts/:id/logs`. Older `/attempts/boards/*` and
+  `/attempts/:id/stop` paths now return HTTP 410 with pointers to the canonical shape.
 - Attempt Git: `GET /attempts/:id/git/status`, `GET /attempts/:id/git/file`,
   `POST /attempts/:id/git/commit|push|merge`, `POST /attempts/:id/github/pr`
 

--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,6 @@
   "workspaces": {
     "": {
       "name": "kanbanAI",
-      "dependencies": {
-        "adm-zip": "^0.5.16",
-      },
       "devDependencies": {
         "@vitest/coverage-v8": "^4.0.12",
         "bun-types": "latest",

--- a/client/src/api/attempts.ts
+++ b/client/src/api/attempts.ts
@@ -27,24 +27,24 @@ export async function getAttemptLogs(attemptId: string): Promise<AttemptLog[]> {
     return data.logs ?? []
 }
 
-export async function getAttemptDetailForCard(boardId: string, cardId: string): Promise<{
+export async function getAttemptDetailForCard(projectId: string, cardId: string): Promise<{
     attempt: Attempt;
     logs: AttemptLog[];
     conversation: ConversationItem[]
 }> {
-    const res = await fetch(`${SERVER_URL}/boards/${boardId}/cards/${cardId}/attempt`)
+    const res = await fetch(`${SERVER_URL}/projects/${projectId}/cards/${cardId}/attempt`)
     return parseJson<{ attempt: Attempt; logs: AttemptLog[]; conversation: ConversationItem[] }>(res)
 }
 
 export async function startAttemptRequest(params: {
-    boardId: string;
+    projectId: string;
     cardId: string;
     agent: string;
     profileId?: string;
     baseBranch?: string;
     branchName?: string
 }) {
-    const res = await fetch(`${SERVER_URL}/boards/${params.boardId}/cards/${params.cardId}/attempts`, {
+    const res = await fetch(`${SERVER_URL}/projects/${params.projectId}/cards/${params.cardId}/attempts`, {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({
@@ -58,7 +58,7 @@ export async function startAttemptRequest(params: {
 }
 
 export async function followupAttemptRequest(attemptId: string, payload: { prompt: string; profileId?: string }) {
-    const res = await fetch(`${SERVER_URL}/attempts/${attemptId}/followup`, {
+    const res = await fetch(`${SERVER_URL}/attempts/${attemptId}/messages`, {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify(payload),
@@ -70,7 +70,11 @@ export async function followupAttemptRequest(attemptId: string, payload: { promp
 }
 
 export async function stopAttemptRequest(attemptId: string): Promise<void> {
-    const res = await fetch(`${SERVER_URL}/attempts/${attemptId}/stop`, {method: 'POST'})
+    const res = await fetch(`${SERVER_URL}/attempts/${attemptId}`, {
+        method: 'PATCH',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({status: 'stopped'}),
+    })
     if (!res.ok) {
         const text = await res.text()
         throw new Error(text || `Stop failed (${res.status})`)

--- a/client/src/components/kanban/Board.tsx
+++ b/client/src/components/kanban/Board.tsx
@@ -390,7 +390,7 @@ export function Board({ projectId, boardId, state, handlers }: Props) {
                     cardTitle={editingCard.title}
                     cardDescription={editingCard.description ?? ""}
                     cardTicketKey={editingCard.ticketKey ?? null}
-                    boardId={boardId}
+                    projectId={projectId}
                     cardId={editingCard.id}
                     onSubmit={async (values) => {
                         await handlers.onUpdateCard(editingCard.id, values);

--- a/client/src/components/kanban/CardInspector.tsx
+++ b/client/src/components/kanban/CardInspector.tsx
@@ -119,7 +119,7 @@ export function CardInspector({
             setFollowup('')
             await queryClient.invalidateQueries({queryKey: attemptKeys.detail(vars.attemptId)})
             await queryClient.invalidateQueries({queryKey: attemptKeys.logs(vars.attemptId)})
-            await queryClient.invalidateQueries({queryKey: cardAttemptKeys.detail(boardId, card.id)})
+            await queryClient.invalidateQueries({queryKey: cardAttemptKeys.detail(projectId, card.id)})
         },
         onError: (err) => {
             toast({title: 'Follow-up failed', description: err.message, variant: 'destructive'})
@@ -129,7 +129,7 @@ export function CardInspector({
         onSuccess: async (_item, variables) => {
             await queryClient.invalidateQueries({queryKey: attemptKeys.detail(variables.attemptId)})
             await queryClient.invalidateQueries({queryKey: attemptKeys.logs(variables.attemptId)})
-            await queryClient.invalidateQueries({queryKey: cardAttemptKeys.detail(boardId, card.id)})
+            await queryClient.invalidateQueries({queryKey: cardAttemptKeys.detail(projectId, card.id)})
             toast({title: 'Dev script completed', description: 'Check the automation log for output.'})
         },
         onError: (err) => {
@@ -242,7 +242,7 @@ export function CardInspector({
     const messagesEndRef = useRef<HTMLDivElement | null>(null)
     const initialScrolledForCardRef = useRef<string | null>(null)
 
-    const attemptDetailQuery = useCardAttempt(boardId, card.id)
+    const attemptDetailQuery = useCardAttempt(projectId, card.id)
 
     const lastUsedProfileId = useMemo(() => {
         const items = attemptDetailQuery.data?.conversation ?? []
@@ -352,7 +352,7 @@ export function CardInspector({
         attemptId: attempt?.id,
         onStatus: (status) => {
             setAttempt((prev) => (prev ? {...prev, status} as Attempt : prev))
-            queryClient.setQueryData(cardAttemptKeys.detail(boardId, card.id), (prev: {
+            queryClient.setQueryData(cardAttemptKeys.detail(projectId, card.id), (prev: {
                 attempt: Attempt;
                 logs: AttemptLog[];
                 conversation: ConversationItem[]
@@ -366,7 +366,7 @@ export function CardInspector({
             if (!id) return
             const entry = {id: crypto.randomUUID(), attemptId: id, ts: p.ts, level: p.level, message: p.message}
             setLogs((prev) => [...prev, entry])
-            queryClient.setQueryData(cardAttemptKeys.detail(boardId, card.id), (prev: {
+            queryClient.setQueryData(cardAttemptKeys.detail(projectId, card.id), (prev: {
                 attempt: Attempt;
                 logs: AttemptLog[];
                 conversation: ConversationItem[]
@@ -380,7 +380,7 @@ export function CardInspector({
                 if (item.id && prev.some((m) => m.id === item.id)) return prev
                 return [...prev, item]
             })
-            queryClient.setQueryData(cardAttemptKeys.detail(boardId, card.id), (prev: {
+            queryClient.setQueryData(cardAttemptKeys.detail(projectId, card.id), (prev: {
                 attempt: Attempt;
                 logs: AttemptLog[];
                 conversation: ConversationItem[]
@@ -393,7 +393,7 @@ export function CardInspector({
         },
         onSession: (sessionId) => {
             setAttempt((prev) => (prev ? {...prev, sessionId} as Attempt : prev))
-            queryClient.setQueryData(cardAttemptKeys.detail(boardId, card.id), (prev: {
+            queryClient.setQueryData(cardAttemptKeys.detail(projectId, card.id), (prev: {
                 attempt: Attempt;
                 logs: AttemptLog[];
                 conversation: ConversationItem[]
@@ -435,15 +435,15 @@ export function CardInspector({
             setConversation([])
             await queryClient.invalidateQueries({queryKey: attemptKeys.detail(att.id)})
             await queryClient.invalidateQueries({queryKey: attemptKeys.logs(att.id)})
-            await queryClient.invalidateQueries({queryKey: cardAttemptKeys.detail(boardId, card.id)})
+            await queryClient.invalidateQueries({queryKey: cardAttemptKeys.detail(projectId, card.id)})
         },
     })
 
     const startAttempt = async () => {
-        if (!boardId) return
+        if (!projectId) return
         setStarting(true)
         try {
-            await startMutation.mutateAsync({boardId, cardId: card.id, agent, profileId})
+            await startMutation.mutateAsync({projectId, cardId: card.id, agent, profileId})
         } catch (err) {
             console.error('Start attempt failed', err)
         } finally {
@@ -466,7 +466,7 @@ export function CardInspector({
     const stopMutation = useStopAttempt({
         onSuccess: async (_data, variables) => {
             await queryClient.invalidateQueries({queryKey: attemptKeys.detail(variables.attemptId)})
-            await queryClient.invalidateQueries({queryKey: cardAttemptKeys.detail(boardId, card.id)})
+            await queryClient.invalidateQueries({queryKey: cardAttemptKeys.detail(projectId, card.id)})
         },
     })
 

--- a/client/src/components/kanban/card-dialogs/EditCardDialog.tsx
+++ b/client/src/components/kanban/card-dialogs/EditCardDialog.tsx
@@ -31,7 +31,7 @@ type EditProps = BaseDialogProps & {
     cardTicketKey?: string | null;
     onSubmit: (values: CardFormValues) => Promise<void> | void;
     onDelete: () => Promise<void> | void;
-    boardId?: string;
+    projectId: string;
     cardId?: string;
 };
 
@@ -43,7 +43,7 @@ export function EditCardDialog({
     cardTicketKey,
     onSubmit,
     onDelete,
-    boardId,
+    projectId,
     cardId,
 }: EditProps) {
     const [values, setValues] = useState<CardFormValues>({
@@ -74,8 +74,8 @@ export function EditCardDialog({
         if (open && agents.length && !agent) setAgent(agents[0].key);
     }, [open, agents, agent]);
 
-    const attemptDetailQuery = useCardAttempt(boardId, cardId, {
-        enabled: Boolean(open && boardId && cardId),
+    const attemptDetailQuery = useCardAttempt(projectId, cardId, {
+        enabled: Boolean(open && projectId && cardId),
     });
     const logsQuery = useAttemptLogs(attempt?.id, {
         enabled: Boolean(attempt?.id),
@@ -100,7 +100,7 @@ export function EditCardDialog({
             );
             if (attempt?.id) {
                 queryClient.invalidateQueries({
-                    queryKey: cardAttemptKeys.detail(boardId!, cardId!),
+                    queryKey: cardAttemptKeys.detail(projectId, cardId!),
                 });
             }
         },
@@ -120,7 +120,7 @@ export function EditCardDialog({
                 queryKey: attemptKeys.logs(attempt.id),
             });
             queryClient.invalidateQueries({
-                queryKey: cardAttemptKeys.detail(boardId!, cardId!),
+                queryKey: cardAttemptKeys.detail(projectId, cardId!),
             });
         },
         onMessage: (item) => {
@@ -130,7 +130,7 @@ export function EditCardDialog({
                 return [...prev, item];
             });
             queryClient.invalidateQueries({
-                queryKey: cardAttemptKeys.detail(boardId!, cardId!),
+                queryKey: cardAttemptKeys.detail(projectId, cardId!),
             });
         },
     });
@@ -165,7 +165,7 @@ export function EditCardDialog({
             setAttempt(att);
             setConversation([]);
             await queryClient.invalidateQueries({
-                queryKey: cardAttemptKeys.detail(boardId!, cardId!),
+                queryKey: cardAttemptKeys.detail(projectId, cardId!),
             });
             await queryClient.invalidateQueries({
                 queryKey: attemptKeys.logs(att.id),
@@ -174,9 +174,9 @@ export function EditCardDialog({
     });
 
     const startAttempt = async () => {
-        if (!boardId || !cardId) return;
+        if (!projectId || !cardId) return;
         try {
-            await startMutation.mutateAsync({ boardId, cardId, agent });
+            await startMutation.mutateAsync({ projectId, cardId, agent });
         } catch (err) {
             console.error("Start attempt failed", err);
         }
@@ -185,7 +185,7 @@ export function EditCardDialog({
     const stopMutation = useStopAttempt({
         onSuccess: async (_data, { attemptId }) => {
             await queryClient.invalidateQueries({
-                queryKey: cardAttemptKeys.detail(boardId!, cardId!),
+                queryKey: cardAttemptKeys.detail(projectId, cardId!),
             });
             await queryClient.invalidateQueries({
                 queryKey: attemptKeys.detail(attemptId),
@@ -279,7 +279,7 @@ export function EditCardDialog({
                             <Button
                                 size="sm"
                                 onClick={startAttempt}
-                                disabled={!boardId || !cardId}
+                                disabled={!projectId || !cardId}
                             >
                                 Start
                             </Button>

--- a/client/src/hooks/attempts.ts
+++ b/client/src/hooks/attempts.ts
@@ -16,12 +16,12 @@ type CardAttemptResult = { attempt: Attempt; logs: AttemptLog[]; conversation: C
 
 type CardAttemptOptions = Partial<UseQueryOptions<CardAttemptResult>>
 
-export function useCardAttempt(boardId: string | undefined, cardId: string | undefined, options?: CardAttemptOptions) {
-    const enabled = Boolean(boardId && cardId)
-    const key = enabled ? cardAttemptKeys.detail(boardId!, cardId!) : (['card-attempt', 'disabled'] as const)
+export function useCardAttempt(projectId: string | undefined, cardId: string | undefined, options?: CardAttemptOptions) {
+    const enabled = Boolean(projectId && cardId)
+    const key = enabled ? cardAttemptKeys.detail(projectId!, cardId!) : (['card-attempt', 'disabled'] as const)
     return useQuery({
         queryKey: key,
-        queryFn: () => getAttemptDetailForCard(boardId!, cardId!),
+        queryFn: () => getAttemptDetailForCard(projectId!, cardId!),
         enabled,
         ...options,
     })
@@ -54,7 +54,7 @@ export function useAttemptLogs(attemptId: string | undefined, options?: AttemptL
 }
 
 type StartAttemptArgs = {
-    boardId: string;
+    projectId: string;
     cardId: string;
     agent: string;
     profileId?: string;
@@ -68,7 +68,7 @@ export function useStartAttempt(options?: StartAttemptOptions) {
     return useMutation({
         mutationFn: (args: StartAttemptArgs) =>
             startAttemptRequest({
-                boardId: args.boardId,
+                projectId: args.projectId,
                 cardId: args.cardId,
                 agent: args.agent,
                 profileId: args.profileId,

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -39,7 +39,7 @@ export const attemptKeys = {
 
 export const cardAttemptKeys = {
     all: ['card-attempt'] as const,
-    detail: (boardId: string, cardId: string) => [...cardAttemptKeys.all, boardId, cardId] as const,
+    detail: (projectId: string, cardId: string) => [...cardAttemptKeys.all, projectId, cardId] as const,
 }
 
 export const githubKeys = {

--- a/server/src/projects/routes.ts
+++ b/server/src/projects/routes.ts
@@ -91,6 +91,13 @@ const updateCardSchema = z
         }
     });
 
+const startAttemptSchema = z.object({
+    agent: z.enum(["ECHO", "SHELL", "CODEX", "OPENCODE", "DROID"]),
+    profileId: z.string().optional(),
+    baseBranch: z.string().min(1).optional(),
+    branchName: z.string().min(1).optional(),
+});
+
 type BoardContext = { boardId: string; project: ProjectSummary }
 
 const resolveBoardForProject = async (c: any): Promise<BoardContext | null> => {
@@ -136,7 +143,7 @@ function createBoardRouter(resolveBoard: (c: any) => Promise<BoardContext | null
         async (c) => {
             const ctx = await loadContext(c);
             if (ctx instanceof Response) return ctx;
-            const {boardId} = ctx;
+            const {boardId, project} = ctx;
 
             const body = c.req.valid("json");
             const column = await getColumnById(body.columnId);
@@ -165,7 +172,7 @@ function createBoardRouter(resolveBoard: (c: any) => Promise<BoardContext | null
         async (c) => {
             const ctx = await loadContext(c);
             if (ctx instanceof Response) return ctx;
-            const {boardId} = ctx;
+            const {boardId, project} = ctx;
             const cardId = c.req.param("cardId");
 
             const card = await getCardById(cardId);
@@ -330,27 +337,24 @@ function createBoardRouter(resolveBoard: (c: any) => Promise<BoardContext | null
     // Start an attempt for a card within this board
     boardRouter.post(
         "/cards/:cardId/attempts",
-        zValidator(
-            "json",
-            z.object({
-                agent: z.enum(["ECHO", "SHELL", "CODEX", "OPENCODE", "DROID"]),
-                profileId: z.string().optional(),
-                baseBranch: z.string().min(1).optional(),
-                branchName: z.string().min(1).optional(),
-            })
-        ),
+        zValidator("json", startAttemptSchema),
         async (c) => {
             const ctx = await loadContext(c);
             if (ctx instanceof Response) return ctx;
-            const {boardId} = ctx;
+            const {boardId, project} = ctx;
             const body = c.req.valid("json");
             try {
-                // Disallow starting attempts for tasks already in Done
+                // Disallow starting attempts for tasks already in Done/blocked
                 const card = await getCardById(c.req.param("cardId"));
                 if (!card) return c.json({error: "Card not found"}, 404);
                 const column = await getColumnById(card.columnId);
-                if (column?.title === "Done")
+                const colTitle = (column?.title || "").trim().toLowerCase();
+                if (colTitle === "done")
                     return c.json({error: "Task is done and locked"}, 409);
+                try {
+                    const {blocked} = await projectDeps.isCardBlocked(card.id);
+                    if (blocked) return c.json({error: "Task is blocked by dependencies"}, 409);
+                } catch {}
 
                 const events = c.get("events");
                 const attempt = await attempts.startAttempt(
@@ -363,6 +367,11 @@ function createBoardRouter(resolveBoard: (c: any) => Promise<BoardContext | null
                         branchName: body.branchName,
                     },
                     {events},
+                );
+                c.header("Deprecation", "true");
+                c.header(
+                    "Link",
+                    `</api/v1/projects/${project.id}/cards/${c.req.param("cardId")}/attempts>; rel="successor-version"`,
                 );
                 return c.json(attempt, 201);
             } catch (error) {
@@ -424,6 +433,12 @@ function createBoardRouter(resolveBoard: (c: any) => Promise<BoardContext | null
 export const createProjectsRouter = () => {
     const router = new Hono<AppEnv>();
 
+    const loadProjectBoard = async (c: any): Promise<BoardContext | Response> => {
+        const ctx = await resolveBoardForProject(c);
+        if (!ctx) return c.json({error: "Project not found"}, 404);
+        return ctx;
+    };
+
     router.get("/", async (c) => {
         const {projects} = c.get("services");
         const result = await projects.list();
@@ -452,6 +467,65 @@ export const createProjectsRouter = () => {
         if (!project) return c.json({error: "Project not found"}, 404);
         return c.json(project, 200);
     });
+
+    router.get("/:projectId/cards/:cardId/attempt", async (c) => {
+        const ctx = await loadProjectBoard(c);
+        if (ctx instanceof Response) return ctx;
+        const {boardId} = ctx;
+        try {
+            const data = await attempts.getLatestAttemptForCard(boardId, c.req.param("cardId"));
+            if (!data) return c.json({error: "Not found"}, 404);
+            return c.json(data, 200);
+        } catch (error) {
+            console.error("[attempts:attempt] failed", error);
+            return c.json({
+                error: error instanceof Error ? error.message : "Failed to fetch attempt",
+            }, 500);
+        }
+    });
+
+    router.post(
+        "/:projectId/cards/:cardId/attempts",
+        zValidator("json", startAttemptSchema),
+        async (c) => {
+            const ctx = await loadProjectBoard(c);
+            if (ctx instanceof Response) return ctx;
+            const {boardId} = ctx;
+            const body = c.req.valid("json");
+            try {
+                const card = await getCardById(c.req.param("cardId"));
+                if (!card) return c.json({error: "Card not found"}, 404);
+                if (card.boardId && card.boardId !== boardId)
+                    return c.json({error: "Card does not belong to this project"}, 400);
+                const column = await getColumnById(card.columnId);
+                const colTitle = (column?.title || "").trim().toLowerCase();
+                if (colTitle === "done") return c.json({error: "Task is done and locked"}, 409);
+                try {
+                    const {blocked} = await projectDeps.isCardBlocked(card.id);
+                    if (blocked) return c.json({error: "Task is blocked by dependencies"}, 409);
+                } catch {}
+
+                const events = c.get("events");
+                const attempt = await attempts.startAttempt(
+                    {
+                        boardId,
+                        cardId: c.req.param("cardId"),
+                        agent: body.agent,
+                        profileId: body.profileId,
+                        baseBranch: body.baseBranch,
+                        branchName: body.branchName,
+                    },
+                    {events},
+                );
+                return c.json(attempt, 201);
+            } catch (error) {
+                console.error("[attempts:start:project] failed", error);
+                return c.json({
+                    error: error instanceof Error ? error.message : "Failed to start attempt",
+                }, 500);
+            }
+        },
+    );
 
     router.route("/:projectId/board", createBoardRouter(resolveBoardForProject));
 


### PR DESCRIPTION
Update the attempts API to utilize project-based routes instead of board-based ones. Adjust client-side hooks, services, and UI components to align with the new API structure. Ensure documentation reflects these changes and run tests to confirm functionality.