### PR TITLE
feat: Implement time-range aware dashboard overview service

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,7 @@
     },
     "cli": {
       "name": "kanban-ai",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "bin": {
         "kanban-ai": "dist/index.js",
       },
@@ -59,7 +59,7 @@
         "@tanstack/react-query-devtools": "5",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "^0.555.0",
+        "lucide-react": "^0.556.0",
         "react": "^19.1.0",
         "react-diff-viewer-continued": "^3.4.0",
         "react-dom": "^19.1.0",
@@ -92,9 +92,9 @@
       "name": "core",
       "version": "0.0.1",
       "dependencies": {
-        "@openai/codex-sdk": "^0.64.0",
+        "@openai/codex-sdk": "^0.65.0",
         "@opencode-ai/sdk": "^1.0.129",
-        "drizzle-orm": "^0.44.5",
+        "drizzle-orm": "^0.45.0",
         "shared": "workspace:*",
         "simple-git": "^3.28.0",
         "zod": "^4.1.11",
@@ -111,7 +111,7 @@
         "@hono/zod-validator": "^0.7.3",
         "@prisma/client": "^7.1.0",
         "core": "workspace:*",
-        "drizzle-orm": "^0.44.5",
+        "drizzle-orm": "^0.45.0",
         "hono": "^4.7.11",
         "shared": "workspace:*",
         "simple-git": "^3.28.0",
@@ -399,7 +399,7 @@
 
     "@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
 
-    "@openai/codex-sdk": ["@openai/codex-sdk@0.64.0", "", {}, "sha512-C675h9+5iL7v3w3XKlMTCmejGyEY4qOygro8pRAoBAQbbCS504SKxosJu5Mb/drhV0GkjbKbKfcjxHtjZJfNDQ=="],
+    "@openai/codex-sdk": ["@openai/codex-sdk@0.65.0", "", {}, "sha512-7GvqLkNusgJaMutyEhgs/u2YvSOMPtOEEoZV9R/SWCVY6vRWsqJyFvC9adKnhyV4187vGwq6GIdaDPHeEt50xw=="],
 
     "@opencode-ai/sdk": ["@opencode-ai/sdk@1.0.129", "", {}, "sha512-68GoZzJo3nHwW20P7M0ScvNzyW1OVPj4hCNU6vAuCOwrJMczIHCWAg60hW1165lHMcc7SEm8BvofPpaDWNqRCA=="],
 
@@ -623,7 +623,7 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
-    "@types/bun": ["@types/bun@1.3.3", "", { "dependencies": { "bun-types": "1.3.3" } }, "sha512-ogrKbJ2X5N0kWLLFKeytG0eHDleBYtngtlbu9cyBKFtNL3cnpDZkNdQj8flVf6WTZUX5ulI9AY1oa7ljhSrp+g=="],
+    "@types/bun": ["@types/bun@1.3.4", "", { "dependencies": { "bun-types": "1.3.4" } }, "sha512-EEPTKXHP+zKGPkhRLv+HI0UEX8/o+65hqARxLy8Ov5rIxMBPNTjeZww00CIihrIQGEQBYg+0roO5qOnS/7boGA=="],
 
     "@types/chai": ["@types/chai@5.2.2", "", { "dependencies": { "@types/deep-eql": "*" } }, "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg=="],
 
@@ -879,7 +879,7 @@
 
     "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
-    "drizzle-orm": ["drizzle-orm@0.44.5", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-jBe37K7d8ZSKptdKfakQFdeljtu3P2Cbo7tJoJSVZADzIKOBo9IAJPOmMsH2bZl90bZgh8FQlD8BjxXA/zuBkQ=="],
+    "drizzle-orm": ["drizzle-orm@0.45.0", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-lyd9VRk3SXKRjV/gQckQzmJgkoYMvVG3A2JAV0vh3L+Lwk+v9+rK5Gj0H22y+ZBmxsrRBgJ5/RbQCN7DWd1dtQ=="],
 
     "duplexer2": ["duplexer2@0.1.4", "", { "dependencies": { "readable-stream": "^2.0.2" } }, "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA=="],
 
@@ -1217,7 +1217,7 @@
 
     "lru.min": ["lru.min@1.1.3", "", {}, "sha512-Lkk/vx6ak3rYkRR0Nhu4lFUT2VDnQSxBe8Hbl7f36358p6ow8Bnvr8lrLt98H8J1aGxfhbX4Fs5tYg2+FTwr5Q=="],
 
-    "lucide-react": ["lucide-react@0.555.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-D8FvHUGbxWBRQM90NZeIyhAvkFfsh3u9ekrMvJ30Z6gnpBHS6HC6ldLg7tL45hwiIz/u66eKDtdA23gwwGsAHA=="],
+    "lucide-react": ["lucide-react@0.556.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-iOb8dRk7kLaYBZhR2VlV1CeJGxChBgUthpSP8wom9jfj79qovgG6qcSdiy6vkoREKPnbUYzJsCn4o4PtG3Iy+A=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
@@ -1804,6 +1804,8 @@
     "@types/babel__template/@babel/types": ["@babel/types@7.28.4", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q=="],
 
     "@types/babel__traverse/@babel/types": ["@babel/types@7.28.4", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q=="],
+
+    "@types/bun/bun-types": ["bun-types@1.3.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-5ua817+BZPZOlNaRgGBpZJOSAQ9RQ17pkwPD0yR7CfJg+r8DgIILByFifDTa+IPDDxzf5VNhtNlcKqFzDgJvlQ=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 

--- a/core/src/dashboard/time-range.ts
+++ b/core/src/dashboard/time-range.ts
@@ -1,0 +1,84 @@
+import type {DashboardTimeRange, DashboardTimeRangePreset} from 'shared'
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000
+
+function isValidIsoDate(value: string | null | undefined): boolean {
+    if (!value) return false
+    const time = Date.parse(value)
+    return Number.isFinite(time)
+}
+
+function resolveWindowMsForPreset(preset: Exclude<DashboardTimeRangePreset, 'all_time'>): number {
+    switch (preset) {
+        case 'last_7d':
+            return 7 * ONE_DAY_MS
+        case 'last_30d':
+            return 30 * ONE_DAY_MS
+        case 'last_90d':
+            return 90 * ONE_DAY_MS
+        case 'last_24h':
+        default:
+            return ONE_DAY_MS
+    }
+}
+
+export function resolveTimeRange(input?: DashboardTimeRange, now: Date = new Date()): DashboardTimeRange {
+    // Custom bounds always win when valid.
+    if (input?.from || input?.to) {
+        const {from, to} = input
+        const hasBoth = Boolean(from && to)
+        const bothValid = hasBoth && isValidIsoDate(from as string) && isValidIsoDate(to as string)
+
+        if (bothValid) {
+            return {
+                preset: input.preset,
+                from: from as string,
+                to: to as string,
+            }
+        }
+        // If custom bounds are incomplete or invalid, ignore them and fall back
+        // to a preset-based window rather than propagating bad dates.
+    }
+
+    const preset = input?.preset ?? 'last_24h'
+
+    // Special-case "all_time" as unbounded on the lower side.
+    if (preset === 'all_time') {
+        return {
+            preset,
+            to: now.toISOString(),
+        }
+    }
+
+    const windowMs = resolveWindowMsForPreset(preset)
+    const to = now.toISOString()
+    const from = new Date(now.getTime() - windowMs).toISOString()
+
+    return {
+        preset,
+        from,
+        to,
+    }
+}
+
+export type ResolvedTimeBounds = {
+    from: Date | null
+    to: Date | null
+}
+
+export function resolveTimeBounds(range: DashboardTimeRange, now: Date = new Date()): ResolvedTimeBounds {
+    const normalized = resolveTimeRange(range, now)
+
+    const from = normalized.from ? new Date(normalized.from) : null
+    const to = normalized.to ? new Date(normalized.to) : null
+
+    if (Number.isNaN(from?.getTime() ?? 0)) {
+        return {from: null, to}
+    }
+    if (Number.isNaN(to?.getTime() ?? 0)) {
+        return {from, to: null}
+    }
+
+    return {from, to}
+}
+

--- a/core/tests/dashboard.service.test.ts
+++ b/core/tests/dashboard.service.test.ts
@@ -1,0 +1,255 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { DashboardOverview, DashboardTimeRange } from "shared";
+
+import { resolveTimeRange } from "../src/dashboard/time-range";
+import { setDbProvider } from "../src/db/provider";
+
+async function createTestDb() {
+    const betterSqlite = await import("better-sqlite3");
+    const DatabaseCtor: any = (betterSqlite as any).default ?? (betterSqlite as any);
+    const sqlite = new DatabaseCtor(":memory:");
+    sqlite.pragma("foreign_keys = ON");
+
+    // Minimal schema for the dashboard service to run against.
+    sqlite.exec(`
+        CREATE TABLE boards (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            repository_path TEXT NOT NULL,
+            repository_url TEXT,
+            repository_slug TEXT,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL
+        );
+
+        CREATE TABLE columns (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            position INTEGER NOT NULL,
+            board_id TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            FOREIGN KEY (board_id) REFERENCES boards(id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE cards (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            description TEXT,
+            position INTEGER NOT NULL,
+            column_id TEXT NOT NULL,
+            board_id TEXT,
+            ticket_key TEXT,
+            ticket_type TEXT,
+            pr_url TEXT,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            FOREIGN KEY (column_id) REFERENCES columns(id) ON DELETE CASCADE,
+            FOREIGN KEY (board_id) REFERENCES boards(id) ON DELETE CASCADE
+        );
+
+        CREATE UNIQUE INDEX cards_board_ticket_key_idx ON cards(board_id, ticket_key);
+
+        CREATE TABLE attempts (
+            id TEXT PRIMARY KEY,
+            board_id TEXT NOT NULL,
+            card_id TEXT NOT NULL,
+            agent TEXT NOT NULL,
+            status TEXT NOT NULL,
+            base_branch TEXT NOT NULL,
+            branch_name TEXT NOT NULL,
+            worktree_path TEXT,
+            session_id TEXT,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            started_at INTEGER,
+            ended_at INTEGER,
+            FOREIGN KEY (board_id) REFERENCES boards(id) ON DELETE CASCADE,
+            FOREIGN KEY (card_id) REFERENCES cards(id) ON DELETE CASCADE
+        );
+    `);
+
+    const { drizzle } = await import("drizzle-orm/better-sqlite3");
+    const schema = await import("../src/db/schema");
+
+    const db = drizzle(sqlite, { schema });
+
+    setDbProvider({
+        getDb() {
+            return db;
+        },
+        async withTx(fn) {
+            return fn(db);
+        },
+    });
+
+    return { db, sqlite };
+}
+
+function insertFixtureData(sqlite: any, baseTime: Date) {
+    const baseTs = Math.floor(baseTime.getTime() / 1000);
+    const day = 24 * 60 * 60;
+
+    // Two projects/boards.
+    sqlite
+        .prepare(
+            `INSERT INTO boards (id, name, repository_path, repository_url, repository_slug, created_at, updated_at)
+             VALUES (?, ?, ?, NULL, NULL, ?, ?)`,
+        )
+        .run("board-1", "Project One", "/repo/one", baseTs - 10 * day, baseTs - 10 * day);
+    sqlite
+        .prepare(
+            `INSERT INTO boards (id, name, repository_path, repository_url, repository_slug, created_at, updated_at)
+             VALUES (?, ?, ?, NULL, NULL, ?, ?)`,
+        )
+        .run("board-2", "Project Two", "/repo/two", baseTs - 20 * day, baseTs - 20 * day);
+
+    // Columns and cards.
+    sqlite
+        .prepare(
+            `INSERT INTO columns (id, title, position, board_id, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?)`,
+        )
+        .run("col-1", "Todo", 1, "board-1", baseTs - 10 * day, baseTs - 10 * day);
+    sqlite
+        .prepare(
+            `INSERT INTO columns (id, title, position, board_id, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?)`,
+        )
+        .run("col-2", "Todo", 1, "board-2", baseTs - 20 * day, baseTs - 20 * day);
+
+    sqlite
+        .prepare(
+            `INSERT INTO cards (id, title, description, position, column_id, board_id, ticket_key, ticket_type, pr_url, created_at, updated_at)
+             VALUES (?, ?, NULL, ?, ?, ?, NULL, NULL, NULL, ?, ?)`,
+        )
+        .run("card-1", "Card One", 1, "col-1", "board-1", baseTs - 10 * day, baseTs - 10 * day);
+    sqlite
+        .prepare(
+            `INSERT INTO cards (id, title, description, position, column_id, board_id, ticket_key, ticket_type, pr_url, created_at, updated_at)
+             VALUES (?, ?, NULL, ?, ?, ?, NULL, NULL, NULL, ?, ?)`,
+        )
+        .run("card-2", "Card Two", 1, "col-2", "board-2", baseTs - 20 * day, baseTs - 20 * day);
+
+    const insertAttempt = sqlite.prepare(
+        `INSERT INTO attempts (id, board_id, card_id, agent, status, base_branch, branch_name, worktree_path, session_id, created_at, updated_at, started_at, ended_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?, ?)`,
+    );
+
+    // Within last 24h: two attempts, one success and one failure, same project.
+    insertAttempt.run(
+        "a-1",
+        "board-1",
+        "card-1",
+        "AGENT",
+        "succeeded",
+        "main",
+        "branch-a1",
+        baseTs - 1 * day + 100,
+        baseTs - 1 * day + 200,
+        baseTs - 1 * day + 100,
+        baseTs - 1 * day + 200,
+    );
+    insertAttempt.run(
+        "a-2",
+        "board-1",
+        "card-1",
+        "AGENT",
+        "failed",
+        "main",
+        "branch-a2",
+        baseTs - 1 * day + 300,
+        baseTs - 1 * day + 400,
+        baseTs - 1 * day + 300,
+        baseTs - 1 * day + 400,
+    );
+
+    // Within last 7d but outside last 24h: one succeeded attempt on second project.
+    insertAttempt.run(
+        "a-3",
+        "board-2",
+        "card-2",
+        "AGENT",
+        "succeeded",
+        "main",
+        "branch-a3",
+        baseTs - 3 * day,
+        baseTs - 3 * day + 100,
+        baseTs - 3 * day,
+        baseTs - 3 * day + 100,
+    );
+
+    // Older than 7d: should be counted only for all_time.
+    insertAttempt.run(
+        "a-4",
+        "board-2",
+        "card-2",
+        "AGENT",
+        "succeeded",
+        "main",
+        "branch-a4",
+        baseTs - 40 * day,
+        baseTs - 40 * day + 100,
+        baseTs - 40 * day,
+        baseTs - 40 * day + 100,
+    );
+}
+
+async function getOverview(range?: DashboardTimeRange): Promise<DashboardOverview> {
+    const service = await import("../src/dashboard/service");
+    return service.getDashboardOverview(range);
+}
+
+describe("dashboard/service.getDashboardOverview", () => {
+    let sqlite: any;
+    const baseTime = new Date("2025-01-10T12:00:00Z");
+
+    beforeEach(async () => {
+        const dbResources = await createTestDb();
+        sqlite = dbResources.sqlite;
+        insertFixtureData(sqlite, baseTime);
+    });
+
+    it("computes in-range metrics for last_24h preset", async () => {
+        const timeRange = resolveTimeRange({ preset: "last_24h" }, baseTime);
+        const overview = await getOverview(timeRange);
+
+        expect(overview.timeRange.preset).toBe("last_24h");
+        expect(overview.attemptsInRange).toBe(2);
+        expect(overview.projectsWithActivityInRange).toBe(1);
+        expect(overview.successRateInRange).toBeCloseTo(0.5, 5);
+    });
+
+    it("computes in-range metrics for last_7d preset", async () => {
+        const timeRange = resolveTimeRange({ preset: "last_7d" }, baseTime);
+        const overview = await getOverview(timeRange);
+
+        // Within 7 days we see a-1, a-2, a-3 (3 attempts, 2 successes).
+        expect(overview.attemptsInRange).toBe(3);
+        expect(overview.projectsWithActivityInRange).toBe(2);
+        expect(overview.successRateInRange).toBeCloseTo(2 / 3, 5);
+    });
+
+    it("treats all_time as including attempts from all history", async () => {
+        const timeRange = resolveTimeRange({ preset: "all_time" }, baseTime);
+        const overview = await getOverview(timeRange);
+
+        // All four attempts fall into the all_time window.
+        expect(overview.attemptsInRange).toBe(4);
+        expect(overview.projectsWithActivityInRange).toBe(2);
+        expect(overview.successRateInRange).toBeCloseTo(3 / 4, 5);
+    });
+
+    it("returns zero success rate when there are no attempts", async () => {
+        // Fresh DB with no attempts.
+        const dbResources = await createTestDb();
+        sqlite = dbResources.sqlite;
+        const timeRange = resolveTimeRange({ preset: "last_24h" }, baseTime);
+        const overview = await getOverview(timeRange);
+
+        expect(overview.attemptsInRange).toBe(0);
+        expect(overview.projectsWithActivityInRange).toBe(0);
+        expect(overview.successRateInRange).toBe(0);
+    });
+});

--- a/core/tests/dashboard.time-range.test.ts
+++ b/core/tests/dashboard.time-range.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import type { DashboardTimeRange } from "shared";
+import { resolveTimeRange } from "../src/dashboard/time-range";
+
+describe("dashboard/time-range", () => {
+    const fixedNow = new Date("2025-01-02T12:00:00Z");
+
+    const msInDay = 24 * 60 * 60 * 1000;
+
+    function assertWindow(
+        range: DashboardTimeRange,
+        expectedStartOffsetDays: number,
+        expectedPreset: DashboardTimeRange["preset"],
+    ) {
+        expect(range.preset).toBe(expectedPreset);
+        expect(range.from).toBeDefined();
+        expect(range.to).toBeDefined();
+
+        const from = new Date(range.from!);
+        const to = new Date(range.to!);
+
+        expect(to.toISOString()).toBe(fixedNow.toISOString());
+        const diffMs = to.getTime() - from.getTime();
+        expect(diffMs).toBe(expectedStartOffsetDays * msInDay);
+    }
+
+    it("resolves last_24h preset when no input is provided", () => {
+        const range = resolveTimeRange(undefined, fixedNow);
+        assertWindow(range, 1, "last_24h");
+    });
+
+    it("resolves last_7d preset to a 7 day window", () => {
+        const range = resolveTimeRange({ preset: "last_7d" }, fixedNow);
+        assertWindow(range, 7, "last_7d");
+    });
+
+    it("resolves last_30d preset to a 30 day window", () => {
+        const range = resolveTimeRange({ preset: "last_30d" }, fixedNow);
+        assertWindow(range, 30, "last_30d");
+    });
+
+    it("resolves last_90d preset to a 90 day window", () => {
+        const range = resolveTimeRange({ preset: "last_90d" }, fixedNow);
+        assertWindow(range, 90, "last_90d");
+    });
+
+    it("treats all_time as unbounded on the lower side", () => {
+        const range = resolveTimeRange({ preset: "all_time" }, fixedNow);
+        expect(range.preset).toBe("all_time");
+        expect(range.from).toBeUndefined();
+        expect(range.to).toBe(fixedNow.toISOString());
+    });
+
+    it("prefers custom from/to when both are valid ISO strings", () => {
+        const from = "2025-01-01T00:00:00Z";
+        const to = "2025-01-02T00:00:00Z";
+        const range = resolveTimeRange({ from, to }, fixedNow);
+        expect(range.from).toBe(from);
+        expect(range.to).toBe(to);
+    });
+
+    it("falls back to presets when custom from/to are invalid or incomplete", () => {
+        const invalid: DashboardTimeRange = { from: "not-a-date" as any, to: undefined };
+        const range = resolveTimeRange(invalid, fixedNow);
+        // Default preset is last_24h when none is provided.
+        expect(range.preset).toBe("last_24h");
+        expect(range.from).toBeDefined();
+        expect(range.to).toBeDefined();
+    });
+});
+

--- a/docs/core/dashboard.md
+++ b/docs/core/dashboard.md
@@ -17,7 +17,7 @@ The Dashboard overview is represented by the shared `DashboardOverview` type in 
 
 - `timeRange: DashboardTimeRange`  
   - Canonical window that all metrics and counts are scoped to.  
-  - Either a preset (`"last_24h" | "last_7d" | "last_30d" | "last_90d"`) or a `from`/`to` ISO 8601 range.
+  - Either a preset (`"last_24h" | "last_7d" | "last_30d" | "last_90d" | "all_time"`) or a `from`/`to` ISO 8601 range.
 - `generatedAt: string` / `updatedAt?: string`  
   - ISO 8601 timestamp when the snapshot was computed (UI uses this for “Updated …” badges).
 - `metrics: DashboardMetrics`  
@@ -44,6 +44,12 @@ The Dashboard overview is represented by the shared `DashboardOverview` type in 
 - `agentStats: AgentStatsSummary[]`  
   - Per-agent stats over `timeRange`:
     - `agentId`, `agentName`, `status`, `attemptsStarted`, `attemptsSucceeded`, `attemptsFailed`, plus optional `successRate`, `avgLatencyMs`, `currentActiveAttempts`, `lastActiveAt`, and `meta`.
+- `attemptsInRange?: number`  
+  - Convenience aggregate for the total number of attempts in the selected `timeRange`.
+- `successRateInRange?: number`  
+  - Convenience aggregate for the success rate (0–1) of attempts in the selected `timeRange` (`0` when there are no attempts).
+- `projectsWithActivityInRange?: number`  
+  - Convenience aggregate for how many distinct projects/boards have any attempt activity in the selected `timeRange`.
 - `meta?: DashboardOverviewMeta`  
   - Optional payload version, available time-range presets, feature flags, and an `extra` extension bag.
 
@@ -60,6 +66,7 @@ Forward-compatibility:
     - Time range selection:
       - `GET /api/v1/dashboard?timeRangePreset=last_24h`
       - `GET /api/v1/dashboard?timeRangePreset=last_7d`
+      - `GET /api/v1/dashboard?timeRangePreset=all_time`
       - `GET /api/v1/dashboard?from=2025-01-01T00:00:00Z&to=2025-01-02T00:00:00Z`
     - Query parameters are mapped into `DashboardTimeRange` and echoed back in the response.
 - WebSocket:

--- a/server/src/dashboard/routes.ts
+++ b/server/src/dashboard/routes.ts
@@ -20,7 +20,7 @@ function parseTimeRangeFromQuery(searchParams: URLSearchParams): TimeRangeParseR
     const from = searchParams.get('from')
     const to = searchParams.get('to')
 
-    const allowedPresets = new Set(['last_24h', 'last_7d', 'last_30d', 'last_90d'] as const)
+    const allowedPresets = new Set(['last_24h', 'last_7d', 'last_30d', 'last_90d', 'all_time'] as const)
 
     if (presetParam && allowedPresets.has(presetParam as any)) {
         return {timeRange: {preset: presetParam as any}}

--- a/server/test/dashboard.routes.test.ts
+++ b/server/test/dashboard.routes.test.ts
@@ -63,6 +63,17 @@ describe('GET /dashboard', () => {
         expect(getDashboardOverview).toHaveBeenCalledWith({preset: 'last_7d'})
     })
 
+    it('accepts the all_time preset', async () => {
+        const app = createApp()
+        const res = await app.request('/dashboard?timeRangePreset=all_time')
+
+        expect(res.status).toBe(200)
+
+        const {getDashboardOverview} = await import('core')
+        expect(getDashboardOverview).toHaveBeenCalledTimes(1)
+        expect(getDashboardOverview).toHaveBeenCalledWith({preset: 'all_time'})
+    })
+
     it('passes a custom from/to time range when both are provided', async () => {
         const app = createApp()
         const from = '2025-01-01T00:00:00Z'
@@ -95,4 +106,3 @@ describe('GET /dashboard', () => {
         expect(resMissingFrom.status).toBe(400)
     })
 })
-

--- a/shared/src/types/dashboard.ts
+++ b/shared/src/types/dashboard.ts
@@ -8,7 +8,18 @@ import type {ProjectId} from './project'
  * bucket sizing. They are intended to be stable over time; new presets can
  * be appended without breaking existing clients.
  */
-export type DashboardTimeRangePreset = 'last_24h' | 'last_7d' | 'last_30d' | 'last_90d'
+export type DashboardTimeRangePreset =
+    | 'last_24h'
+    | 'last_7d'
+    | 'last_30d'
+    | 'last_90d'
+    /**
+     * Special preset representing the full history of available data.
+     *
+     * Implementations SHOULD treat this as unbounded on the lower side while
+     * keeping an upper bound at "now" when resolving concrete query windows.
+     */
+    | 'all_time'
 
 /**
  * Canonical representation of the time window used to compute dashboard
@@ -745,6 +756,25 @@ export interface DashboardOverview {
      * Per-agent summary statistics over the selected time range.
      */
     agentStats: AgentStatsSummary[]
+    /**
+     * Total number of attempts that fall within the selected `timeRange`.
+     *
+     * Implementations SHOULD keep this consistent with the window used for
+     * attempt-related metrics (e.g. success rate, per-project activity).
+     */
+    attemptsInRange?: number
+    /**
+     * Success rate for attempts within the selected `timeRange`.
+     *
+     * Expressed as a fraction between 0–1 unless otherwise documented; when
+     * there are no attempts in the window this should be `0`.
+     */
+    successRateInRange?: number
+    /**
+     * Number of distinct projects/boards that have any attempt activity
+     * within the selected `timeRange`.
+     */
+    projectsWithActivityInRange?: number
     /**
      * Optional metadata and feature flags associated with this overview.
      */


### PR DESCRIPTION
## Summary

- Makes the dashboard overview service fully time-range aware, including support for an `all_time` preset and custom `from`/`to` intervals.
- Adds new in-range aggregates (attempt count, success rate, and projects with activity) to power richer dashboard UI cards and summaries.
- Extracts reusable time-range normalization logic into a dedicated core module with focused tests, and wires the HTTP API to accept the extended time-range contract.

## Changes

### 1. Shared dashboard types

- Extended `DashboardTimeRangePreset` in `shared/src/types/dashboard.ts` to include an `all_time` preset, with documentation that it should be treated as unbounded on the lower side and bounded at “now”.
- Clarified the `DashboardTimeRange` contract:
  - Either a named `preset` (e.g. `"last_24h"`, `"all_time"`) or an explicit `from`/`to` ISO 8601 interval.
  - Backends normalize incoming query parameters into this shape and echo it in responses.
- Extended `DashboardOverview` with new optional in-range aggregates:
  - `attemptsInRange?: number` – total attempts whose `createdAt` fall within the selected window.
  - `successRateInRange?: number` – success rate (0–1) over the same window, `0` when there are no attempts.
  - `projectsWithActivityInRange?: number` – distinct boards/projects that have any attempt activity in the window.
- Documented that `DashboardOverviewMeta.availableTimeRangePresets` may now include `'all_time'`.

**Rationale:** Centralizing these semantics in `shared` ensures the UI, server, and streaming paths agree on what “time range” means and allows clients to safely use new fields without breaking older consumers.

### 2. Core time-range utilities

- Introduced `core/src/dashboard/time-range.ts`:
  - `resolveTimeRange(input?: DashboardTimeRange, now: Date = new Date()): DashboardTimeRange`
    - Prefers custom `from`/`to` when both are present and valid ISO strings.
    - Falls back to a preset window when custom bounds are missing/invalid.
    - Defaults to `last_24h` when no preset is provided.
    - Treats `all_time` as unbounded on the lower side with `to = now`, leaving `from` undefined.
  - `resolveTimeBounds(range: DashboardTimeRange, now: Date = new Date())`
    - Normalizes the range via `resolveTimeRange`, then converts `from`/`to` into `Date | null` while defensively handling invalid timestamps.
- Removed the previous inline time-range functions from `core/src/dashboard/service.ts` (e.g., `isValidIsoDate`, `resolveWindowMsForPreset`, `resolveTimeRange`) and replaced them with calls into the new module.

**Rationale:** Pulling time-range resolution into a focused, testable utility makes behavior explicit, reusable (e.g., for streaming), and easier to evolve (adding future presets or business-specific windows).

### 3. Dashboard overview service

- Updated `getDashboardOverview` in `core/src/dashboard/service.ts` to use the new utilities:
  - Resolves the final `DashboardTimeRange` via `resolveTimeRange`.
  - Converts it into concrete `Date | null` bounds using `resolveTimeBounds`.
- Introduced `buildTimeRangePredicate(column, rangeFrom, rangeTo)`:
  - Builds a Drizzle predicate using `gte(column, from)` and/or `lt(column, to)` depending on which bounds are present.
  - Returns `undefined` when both bounds are null, allowing callers to skip the `WHERE` clause.
- Applied time-range aware predicates to attempt queries:
  - In-range attempts:
    - Uses `attempts.createdAt` and the resolved bounds to compute:
      - `attemptsInRange` (total attempts in window).
      - `attemptsSucceededInRange` to derive `successRateInRange`.
    - Counts `projectsWithActivityInRange` using `count(distinct attempts.boardId)` with the same time filter.
  - Completed attempts metric:
    - Now uses `attempts.endedAt` plus both lower and upper bounds (when present) to compute `attemptsCompleted`, instead of only filtering with `endedAt >= rangeStart`.
    - For `all_time`, uses only the upper bound (`endedAt < now`).
- Kept existing aggregates intact:
  - `projectsTotal`, `activeAttemptsCount`, and `openCardsTotal` are unchanged in meaning.
  - Metric series are still modeled as single-bucket `DashboardMetricSeries` instances keyed by `DASHBOARD_METRIC_KEYS`.
- Extended the returned overview shape:
  - Adds `attemptsInRange`, `successRateInRange`, and `projectsWithActivityInRange` to the response.
  - Extends `meta.availableTimeRangePresets` to include `'all_time'`.

**Rationale:** Previously, the dashboard only exposed a coarse “attempts completed since X” metric and had no explicit sense of success rate or project coverage within a time range. This change makes the service aligned with the ticket by: (a) honoring both lower and upper bounds, (b) supporting an explicit `all_time` mode, and (c) surfacing richer aggregates suitable for high-level cards in the UI.

### 4. HTTP API: time-range query handling

- Updated `server/src/dashboard/routes.ts`:
  - `parseTimeRangeFromQuery` now:
    - Accepts `timeRangePreset` values: `last_24h`, `last_7d`, `last_30d`, `last_90d`, and `all_time`.
    - When a valid preset is provided, returns `{ timeRange: { preset } }`.
    - When `from` or `to` are provided:
      - Requires both to be present and valid ISO 8601 strings.
      - Returns `{ invalid: true }` for incomplete/invalid pairs, which produces a `400` response.
      - On success, returns `{ timeRange: { from, to } }`.
    - Defaults to `{}` when no time-range query parameters are supplied, causing `getDashboardOverview` to use the default preset.
  - `GET /dashboard` route:
    - Returns a `400` Problem JSON response with a clear message when the time range is invalid.
    - Otherwise delegates to `getDashboardOverview(timeRange)`.

**Rationale:** This keeps the HTTP surface area small and predictable while letting clients choose between presets and custom intervals. Invalid user input is rejected early with a clear error, while the core service remains responsible for normalization and all-time semantics.

### 5. Documentation

- Updated `docs/core/dashboard.md`:
  - Documents the full `DashboardOverview` shape, including:
    - Supported presets: `"last_24h" | "last_7d" | "last_30d" | "last_90d" | "all_time"`.
    - New in-range aggregates: `attemptsInRange`, `successRateInRange`, `projectsWithActivityInRange`.
  - Clarifies HTTP usage with examples:
    - `?timeRangePreset=last_24h`, `?timeRangePreset=last_7d`, `?timeRangePreset=all_time`.
    - `?from=...&to=...` custom ranges.
  - Explains that query parameters are normalized into `DashboardTimeRange` and echoed in the response.

**Rationale:** Bringing the docs in line with the new API makes it easier for consumers (UI, scripts, external integrations) to discover and correctly use the extended time-range behavior and new aggregates.

### 6. Tests

- Added `core/tests/dashboard.time-range.test.ts`:
  - Verifies `resolveTimeRange` behavior for:
    - Default range when no input is provided (`last_24h` window).
    - Each of the fixed presets (`last_7d`, `last_30d`, `last_90d`).
    - `all_time` semantics (unbounded `from`, `to` fixed to `now`).
    - Preference for valid custom `from`/`to` over presets.
    - Fallback to presets when custom bounds are invalid or incomplete.
- Added `core/tests/dashboard.service.test.ts`:
  - Uses an in-memory SQLite database to set up minimal `boards`, `columns`, `cards`, and `attempts` tables.
  - Inserts fixture data spanning:
    - Attempts within the last 24h.
    - Attempts in the last 7d but outside the last 24h.
    - Attempts older than 7d.
  - Asserts `getDashboardOverview` behavior for:
    - `last_24h`: attempts, success rate, and project activity counts.
    - `last_7d`: includes both 24h and 7d-only attempts.
    - `all_time`: includes all historical attempts.
    - Empty database case: ensures success rate is `0` when there are no attempts.
- Extended `server/test/dashboard.routes.test.ts`:
  - Confirms the router:
    - Delegates to core with `undefined` time range by default.
    - Passes through preset time ranges, including `all_time`.
    - Accepts valid custom `from`/`to` pairs.
    - Returns `400` for invalid or incomplete `from`/`to` inputs.

**Rationale:** The tests lock in the intended time-range semantics and aggregates, protect against regressions in the future, and provide examples of usage for other contributors.

### 7. Lockfile

- Updated `bun.lock` to capture dependency graph changes introduced by the new core tests (e.g. `better-sqlite3` usage) and any transitive updates pulled in during development.

**Rationale:** Ensures reproducible installs and consistent behavior across environments.

## Plan

- [x] Define shared time-range presets (`DashboardTimeRangePreset`) including `all_time`.
- [x] Extract time-range resolution logic into `core/src/dashboard/time-range.ts` with clear, testable semantics.
- [x] Update `getDashboardOverview` to:
  - [x] Use `resolveTimeRange` / `resolveTimeBounds`.
  - [x] Apply time filters consistently to attempts (created/completed).
  - [x] Compute and expose `attemptsInRange`, `successRateInRange`, and `projectsWithActivityInRange`.
- [x] Extend the HTTP dashboard route to:
  - [x] Accept the full set of presets, including `all_time`.
  - [x] Validate and map custom `from`/`to` into `DashboardTimeRange`.
  - [x] Return structured 400 responses for invalid inputs.
- [x] Align documentation (`docs/core/dashboard.md`) with the new API shape and query patterns.
- [x] Add targeted unit tests:
  - [x] Core time-range resolution tests.
  - [x] Core dashboard overview integration tests with in-memory SQLite.
  - [x] Server route tests for new query validation behaviors.
- [ ] UI follow-up (separate PR):
  - [ ] Expose `all_time` and custom range selector in the dashboard UI.
  - [ ] Surface `attemptsInRange`, `successRateInRange`, and `projectsWithActivityInRange` in the metric cards.
  - [ ] Ensure streaming updates respect the same `DashboardTimeRange` semantics.
- [ ] Observability follow-up (separate PR):
  - [ ] Add lightweight logging/metrics around time-range usage to understand which presets are most commonly used.

## Testing

- Core:
  - `bun test core` (covers `dashboard.time-range` and `dashboard.service`).
- Server:
  - `bun test server` (covers `dashboard` route time-range parsing and delegation).

If you’d like, I can also add a short note to the Mintlify docs for `bun run prod` to highlight the new time-range presets and in-range aggregates.