### PR TITLE
feat: Wire dashboard time range filter to API and persist selection

### DIFF
--- a/client/test/MissionControlDashboardPage.test.tsx
+++ b/client/test/MissionControlDashboardPage.test.tsx
@@ -130,6 +130,7 @@ describe("Mission Control dashboard layout", () => {
     beforeEach(() => {
         cleanup();
         vi.clearAllMocks();
+        window.sessionStorage.clear();
 
         dashboardMocks.useDashboardOverview.mockImplementation(
             (options?: { timeRangePreset?: DashboardTimeRangePreset }) => ({
@@ -187,5 +188,18 @@ describe("Mission Control dashboard layout", () => {
         // KPI helper text reflects the newly selected range.
         const updatedKpiRow = screen.getByRole("group", {name: /Key performance indicators/i});
         expect(within(updatedKpiRow).getByText(/Last 24 hours/i)).toBeTruthy();
+
+        // Selection is persisted for the current session.
+        expect(window.sessionStorage.getItem("dashboard.timeRangePreset")).toBe("last_24h");
+    });
+
+    it("initializes the time range from session storage when available", () => {
+        window.sessionStorage.setItem("dashboard.timeRangePreset", "last_24h");
+
+        renderDashboard();
+
+        expect(dashboardMocks.useDashboardOverview).toHaveBeenCalled();
+        const firstCallOptions = dashboardMocks.useDashboardOverview.mock.calls[0][0];
+        expect(firstCallOptions?.timeRangePreset).toBe("last_24h");
     });
 });

--- a/client/test/dashboardApi.test.ts
+++ b/client/test/dashboardApi.test.ts
@@ -1,0 +1,65 @@
+import {describe, it, expect, beforeEach, vi} from "vitest";
+
+vi.mock("@/lib/env", () => ({
+    SERVER_URL: "http://test-server/api/v1",
+}));
+
+vi.mock("@/api/http", () => ({
+    parseApiResponse: vi.fn(async () => ({
+        timeRange: {preset: "last_7d"},
+        generatedAt: new Date().toISOString(),
+        metrics: {byKey: {}},
+        activeAttempts: [],
+        recentAttemptActivity: [],
+        inboxItems: {
+            review: [],
+            failed: [],
+            stuck: [],
+        },
+        projectSnapshots: [],
+        agentStats: [],
+    })),
+}));
+
+import {getDashboardOverview} from "@/api/dashboard";
+
+describe("api/dashboard.getDashboardOverview", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        // @ts-expect-error - assigning to global fetch in test environment
+        global.fetch = vi.fn().mockResolvedValue(
+            new Response("{}", {
+                status: 200,
+                headers: {"Content-Type": "application/json"},
+            }),
+        );
+    });
+
+    it("calls /dashboard without query parameters when no time range is provided", async () => {
+        await getDashboardOverview();
+
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(global.fetch).toHaveBeenCalledWith("http://test-server/api/v1/dashboard");
+    });
+
+    it("passes timeRangePreset as a query parameter when provided", async () => {
+        await getDashboardOverview({timeRangePreset: "last_24h"});
+
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(global.fetch).toHaveBeenCalledWith(
+            "http://test-server/api/v1/dashboard?timeRangePreset=last_24h",
+        );
+    });
+
+    it("passes from/to query parameters when a custom range is provided", async () => {
+        const from = "2025-01-01T00:00:00.000Z";
+        const to = "2025-01-02T00:00:00.000Z";
+
+        await getDashboardOverview({from, to});
+
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(global.fetch).toHaveBeenCalledWith(
+            `http://test-server/api/v1/dashboard?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`,
+        );
+    });
+});

--- a/docs/guides/dashboard-ui.md
+++ b/docs/guides/dashboard-ui.md
@@ -19,6 +19,7 @@ Presented as **Mission Control** in the app header, this page gives you a high-l
 
 - The drop-down beside the primary actions lets you scope Mission Control to one of the supported presets (`Last 24 hours`, `Last 7 days`, `Last 30 days`).
 - The default preset is **Last 7 days**; changing it refetches the HTTP snapshot, keeps a dedicated query key, and rerenders the metric cards, inbox items, project snapshots, and agent stats for that window.
+- The selected preset is remembered in browser session storage, so navigating away from and back to Mission Control (or soft reloading the page) keeps the last chosen time range for the current session.
 - When the default preset is selected the live WebSocket stream stays connected; choosing a different preset keeps the stream untouched by using a separate cache entry for each range so you still see live updates when you switch back to **Last 7 days**.
 
 ## Metric cards


### PR DESCRIPTION
**Summary**

- Persists the Mission Control dashboard time range preset in browser session storage and restores it on load so the dashboard behaves like a global filter within a session.
- Codifies the dashboard API contract around time range parameters with focused client tests.
- Updates Mission Control documentation to describe the new persistence behavior.

**Motivation / Rationale**

- Users expect the dashboard’s selected time window to “stick” as they navigate around the app or refresh during a working session.
- The dashboard API already supports `timeRangePreset` and `from`/`to` parameters; tests lock in this contract so UI changes can safely rely on it.
- Using `sessionStorage` scopes persistence to the current browser session, avoiding cross-tab bleed while smoothing the experience.

**Changes**

1. **Dashboard time range persistence (`client/src/pages/DashboardPage.tsx`)**
   - Adds `DASHBOARD_TIME_RANGE_STORAGE_KEY = 'dashboard.timeRangePreset'`.
   - Introduces `resolveTimeRangePresetFromStorage()` to:
     - read the stored value from `window.sessionStorage`,
     - validate that it is one of `'last_24h' | 'last_7d' | 'last_30d'`,
     - guard against `window` being undefined or storage throwing (best-effort, no crashes).
   - Adds `storeTimeRangePreset(value)` to persist the current preset back to `sessionStorage`, again with defensive error handling.
   - Switches `timeRangePreset` to a lazy `useState` initializer that:
     - prefers a valid stored preset when present,
     - falls back to `DEFAULT_DASHBOARD_TIME_RANGE_PRESET` otherwise.
   - Adds a `useEffect` that watches `timeRangePreset` and calls `storeTimeRangePreset` on change so the selection is remembered across navigations and soft reloads.
   - Keeps the existing wiring:
     - `useDashboardOverview({ timeRangePreset })` to scope the HTTP snapshot,
     - `useDashboardStream(timeRangePreset === DEFAULT_DASHBOARD_TIME_RANGE_PRESET)` so the live WebSocket stream remains limited to the default preset.

2. **Mission Control UI tests (`client/test/MissionControlDashboardPage.test.tsx`)**
   - Clears `window.sessionStorage` in `beforeEach` to prevent leakage between tests.
   - Extends `"updates time range preset and KPI helper text when selection changes"` to assert that:
     - changing the selector to “Last 24 hours” updates the hook call with `"last_24h"`, and
     - `window.sessionStorage.getItem("dashboard.timeRangePreset")` is `"last_24h"` after the change.
   - Adds `"initializes the time range from session storage when available"` to verify that:
     - pre-populating `sessionStorage` with `"dashboard.timeRangePreset" = "last_24h"` causes the first `useDashboardOverview` call to receive `"last_24h"`,
     - the dashboard therefore respects the stored preset instead of always defaulting to `"last_7d"`.

3. **Dashboard API contract tests (`client/test/dashboardApi.test.ts`)**
   - Mocks `SERVER_URL` to `"http://test-server/api/v1"` and stubs `parseApiResponse` so tests focus on URL construction.
   - Installs a mock `global.fetch` in `beforeEach` returning a simple JSON response.
   - Verifies `getDashboardOverview` builds the expected URLs:
     - no params → `GET http://test-server/api/v1/dashboard` (no query string),
     - `{ timeRangePreset: "last_24h" }` → `GET http://test-server/api/v1/dashboard?timeRangePreset=last_24h`,
     - `{ from, to }` → `GET http://test-server/api/v1/dashboard?from=<encoded>&to=<encoded>`.
   - These tests lock in the existing implementation in `client/src/api/dashboard.ts`, giving the UI a stable, tested surface for time range filtering.

4. **Documentation updates (`docs/guides/dashboard-ui.md`)**
   - Under “Time range selector”, adds a bullet clarifying that:
     - the selected preset is remembered in browser session storage, and
     - navigating away from and back to Mission Control (or soft reloading) within the same session preserves the last chosen time range.

**Ticket Enhancements vs Current Implementation**

- Elevates the dashboard time range from a per-visit filter to a session-global preference, aligning with user expectations for a “Mission Control” view.
- Makes persistence explicit, resilient, and tested instead of relying solely on in-memory React state.
- Adds targeted API tests that were previously missing, reducing risk when evolving the dashboard client or the `DashboardTimeRangeQuery` surface.
- Validates and sanitizes stored values, preventing bad storage state from breaking the UI and ensuring safe behavior in non-browser environments.

**Plan**

- [x] Add a dedicated key (`"dashboard.timeRangePreset"`) and storage helpers for reading/writing the dashboard time range preset from `window.sessionStorage`.
- [x] Initialize `DashboardPage` from any valid stored preset using a lazy `useState` initializer, with a safe fallback to `DEFAULT_DASHBOARD_TIME_RANGE_PRESET`.
- [x] Continue wiring `timeRangePreset` through `useDashboardOverview` and `useDashboardStream` so both the HTTP snapshot and WebSocket stream remain consistent with the selector (stream only active for the default preset).
- [x] Extend Mission Control UI tests to:
  - clear `sessionStorage` between runs,
  - assert persistence after changing the preset,
  - assert initialization from a pre-populated stored value.
- [x] Add focused tests for `api/dashboard.getDashboardOverview` covering:
  - no time range params,
  - a `timeRangePreset`-only request,
  - a `from`/`to` custom range, with proper URL encoding.
- [x] Update dashboard UI docs to describe the session-scoped persistence and set expectations for how the time range behaves as users navigate.
- [ ] Follow-up: evaluate multi-tab persistence (e.g. `localStorage` or a server-side preference) and extend this pattern to any future custom date range picker and other dashboard-wide filters.

**Testing**

- [ ] `bun test` (client workspace) — verify new and existing tests pass.
- [ ] Manual QA via `bun run dev`:
  - change the Mission Control time range and confirm KPIs, panels, and “Updated …” labels reflect the selection,
  - navigate away from `/dashboard` and back, and soft reload, confirming the preset is restored from session storage,
  - check that the WebSocket stream remains active only for the default preset and resumes correctly when switching back.