### PR TITLE
refactor(client): unify page headers across application

### DIFF
--- a/client/src/components/layout/PageHeader.tsx
+++ b/client/src/components/layout/PageHeader.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react'
+
+import {cn} from '@/lib/utils'
+
+export type PageHeaderProps = Omit<React.ComponentPropsWithoutRef<'header'>, 'children' | 'title'> & {
+    title: React.ReactNode
+    description?: React.ReactNode
+    kicker?: React.ReactNode
+    titleAccessory?: React.ReactNode
+    actions?: React.ReactNode
+    children?: React.ReactNode
+    containerClassName?: string
+    testId?: string
+}
+
+export function PageHeader({
+    title,
+    description,
+    kicker,
+    titleAccessory,
+    actions,
+    children,
+    className,
+    containerClassName,
+    testId = 'page-header',
+    ...props
+}: PageHeaderProps) {
+    return (
+        <header
+            data-component="PageHeader"
+            data-testid={testId}
+            className={cn(
+                'border-b border-border/60 bg-card/60 backdrop-blur supports-[backdrop-filter]:bg-card/50',
+                className,
+            )}
+            {...props}
+        >
+            <div
+                className={cn(
+                    'mx-auto flex w-full flex-col gap-3 px-4 py-4 sm:px-6 lg:px-8',
+                    containerClassName,
+                )}
+            >
+                <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                    <div className="min-w-0 space-y-1">
+                        {kicker ? (
+                            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                {kicker}
+                            </p>
+                        ) : null}
+                        <div className="flex flex-wrap items-center gap-3">
+                            <h1 className="text-2xl font-semibold leading-tight text-foreground">
+                                {title}
+                            </h1>
+                            {titleAccessory}
+                        </div>
+                        {description ? (
+                            <div className="text-sm text-muted-foreground">
+                                {description}
+                            </div>
+                        ) : null}
+                    </div>
+                    {actions ? (
+                        <div className="flex flex-wrap items-center gap-2">
+                            {actions}
+                        </div>
+                    ) : null}
+                </div>
+                {children ? (
+                    <div className="flex flex-wrap items-center gap-2">
+                        {children}
+                    </div>
+                ) : null}
+            </div>
+        </header>
+    )
+}
+

--- a/client/src/components/projects/ProjectsLanding.tsx
+++ b/client/src/components/projects/ProjectsLanding.tsx
@@ -1,8 +1,8 @@
 import {Button} from "@/components/ui/button";
-import {Separator} from "@/components/ui/separator";
 import {Loader2, Plus} from "lucide-react";
 import {ProjectCard, type Project} from "./ProjectCard";
 import {EmptyProjects} from "./EmptyProjects";
+import {PageHeader} from "@/components/layout/PageHeader";
 
 interface ProjectsLandingProps {
     projects: Project[];
@@ -24,12 +24,11 @@ export function ProjectsLanding({
                                     error = null,
                                 }: ProjectsLandingProps) {
     return (
-        <div className="min-h-screen bg-background text-foreground">
-            <header className="border-b border-border/50 bg-background/80 backdrop-blur">
-                <div className="flex h-16 items-center justify-between px-4">
-                    <div className="text-lg font-semibold tracking-[0.2em] uppercase text-muted-foreground">
-                        KanbanAI
-                    </div>
+        <div className="flex h-full flex-col overflow-auto bg-background text-foreground">
+            <PageHeader
+                title="Projects"
+                description="Manage your projects and track their progress."
+                actions={
                     <Button
                         variant="outline"
                         size="sm"
@@ -39,19 +38,10 @@ export function ProjectsLanding({
                         <Plus className="size-4"/>
                         Create Project
                     </Button>
-                </div>
-            </header>
+                }
+            />
 
-            <main className="px-4 py-10">
-                <div className="flex flex-col gap-3">
-                    <div>
-                        <h1 className="text-3xl font-black tracking-tight">Projects</h1>
-                        <p className="text-sm text-muted-foreground">
-                            Manage your projects and track their progress.
-                        </p>
-                    </div>
-                    <Separator className="bg-border/50"/>
-                </div>
+            <main className="px-4 py-6 sm:px-6 lg:px-8">
 
                 {loading ? (
                     <div className="mt-10 flex flex-col items-center gap-3 text-muted-foreground">

--- a/client/src/pages/AgentSettingsPage.tsx
+++ b/client/src/pages/AgentSettingsPage.tsx
@@ -14,6 +14,7 @@ import {Input} from '@/components/ui/input'
 import {Textarea} from '@/components/ui/textarea'
 import {Button} from '@/components/ui/button'
 import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@/components/ui/select'
+import {PageHeader} from '@/components/layout/PageHeader'
 
 export function AgentSettingsPage() {
     const params = useParams<{ agentKey: string }>()
@@ -57,13 +58,14 @@ export function AgentSettingsPage() {
     }
 
     return (
-        <div className="flex h-full flex-col gap-4 p-4">
-            <div>
-                <h1 className="text-lg font-semibold">{agentKey} Profiles</h1>
-                <p className="text-sm text-muted-foreground">Create, edit, and delete profiles for this agent.</p>
-            </div>
+        <div className="flex h-full flex-col overflow-auto bg-background">
+            <PageHeader
+                title={`${agentKey} Profiles`}
+                description="Create, edit, and delete profiles for this agent."
+            />
 
-            <div className="grid gap-6 md:grid-cols-[280px_1fr]">
+            <div className="flex-1 px-4 py-6 sm:px-6 lg:px-8">
+                <div className="grid gap-6 md:grid-cols-[280px_1fr]">
                 <div className="space-y-2">
                     <div className="text-sm text-muted-foreground">Existing profiles</div>
                     <div className="space-y-1">
@@ -204,6 +206,7 @@ export function AgentSettingsPage() {
                         </div>
                     )}
                 </div>
+            </div>
             </div>
         </div>
     )

--- a/client/src/pages/AppSettingsPage.tsx
+++ b/client/src/pages/AppSettingsPage.tsx
@@ -11,6 +11,7 @@ import {GitDefaultsSection} from './app-settings/GitDefaultsSection'
 import {GithubSettingsSection} from './app-settings/GithubSettingsSection'
 import {GithubAppCredentialsFields} from '@/components/github/GithubAppCredentialsFields'
 import {describeApiError} from '@/api/http'
+import {PageHeader} from '@/components/layout/PageHeader'
 
 type FormState = {
     theme: 'system' | 'light' | 'dark'
@@ -246,13 +247,14 @@ export function AppSettingsPage() {
     if (data && !form) setForm(initial)
 
     return (
-        <div className="flex h-full flex-col overflow-auto bg-background px-8 py-6">
-            <div className="mx-auto w-full max-w-5xl space-y-6">
-                <div>
-                    <h1 className="text-2xl font-semibold text-foreground">Application Settings</h1>
-                    <p className="mt-2 text-sm text-muted-foreground">Manage global preferences and defaults. Project
-                        settings can override some of these values.</p>
-                </div>
+        <div className="flex h-full flex-col overflow-auto bg-background">
+            <PageHeader
+                title="Application Settings"
+                description="Manage global preferences and defaults. Project settings can override some of these values."
+                containerClassName="max-w-5xl"
+            />
+
+            <div className="mx-auto w-full max-w-5xl space-y-6 px-4 py-6 sm:px-6 lg:px-8">
 
                 {form && (
                     <>

--- a/client/src/pages/AttemptDetailPage.tsx
+++ b/client/src/pages/AttemptDetailPage.tsx
@@ -3,6 +3,7 @@ import {Card, CardContent, CardHeader, CardTitle} from '@/components/ui/card'
 import {Button} from '@/components/ui/button'
 import {StatusBadge} from '@/components/common/StatusBadge'
 import {useAttempt, useAttemptLogs, useRelativeTimeFormatter} from '@/hooks'
+import {PageHeader} from '@/components/layout/PageHeader'
 
 export function AttemptDetailPage() {
     const {attemptId} = useParams<{ attemptId: string }>()
@@ -45,30 +46,30 @@ export function AttemptDetailPage() {
     const updatedLabel = relativeTimeFromNow(attempt.updatedAt ?? attempt.createdAt ?? null)
 
     return (
-        <div className="flex h-full flex-col overflow-auto bg-background px-8 py-6">
-            <div className="mx-auto w-full max-w-5xl space-y-4">
-                <div className="flex items-center justify-between">
-                    <div>
-                        <h1 className="text-xl font-semibold text-foreground">
-                            Attempt {attempt.id.slice(0, 8)}
-                        </h1>
-                        <p className="mt-1 text-xs text-muted-foreground">
-                            Status{' '}
-                            <StatusBadge status={attempt.status} className="align-middle"/>
-                            <span className="ml-2">
-                                · Updated {updatedLabel}
-                            </span>
-                        </p>
-                    </div>
-                    <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+        <div className="flex h-full flex-col overflow-auto bg-background">
+            <PageHeader
+                title={`Attempt ${attempt.id.slice(0, 8)}`}
+                description={
+                    <>
+                        Status{' '}
+                        <StatusBadge status={attempt.status} className="align-middle"/>
+                        <span className="ml-2">· Updated {updatedLabel}</span>
+                    </>
+                }
+                actions={
+                    <>
                         <Button asChild size="sm" variant="outline">
                             <Link to="/dashboard">Back to dashboard</Link>
                         </Button>
                         <Button asChild size="sm" variant="outline">
                             <Link to={`/projects/${attempt.boardId}`}>Open board</Link>
                         </Button>
-                    </div>
-                </div>
+                    </>
+                }
+                containerClassName="max-w-5xl"
+            />
+
+            <div className="mx-auto w-full max-w-5xl space-y-4 px-4 py-6 sm:px-6 lg:px-8">
 
                 <Card className="border-border/70 bg-card/60">
                     <CardHeader>

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -18,6 +18,7 @@ import {ProjectHealthPanel} from '@/pages/dashboard/ProjectHealthPanel'
 import {AgentsSystemStatusPanel} from '@/pages/dashboard/AgentsSystemStatusPanel'
 import {RecentAttemptHistoryPanel} from '@/pages/dashboard/RecentAttemptHistoryPanel'
 import {formatSuccessRate} from '@/pages/dashboard/formatters'
+import {PageHeader} from '@/components/layout/PageHeader'
 import {
     SectionEmptyState,
     SectionErrorBanner,
@@ -175,57 +176,51 @@ export function DashboardPage() {
     }
 
     return (
-        <div className="flex h-full flex-col overflow-auto bg-background px-4 py-4 sm:px-6 sm:py-5 lg:px-8 lg:py-6">
-            <div className="w-full space-y-6">
-                <header className="flex flex-col gap-4 border-b border-border/60 pb-4">
-                    <div className="space-y-2">
-                        <div className="flex flex-wrap items-center gap-3">
-                            <h1 className="text-2xl font-semibold text-foreground">Mission Control</h1>
-                            <VersionIndicator/>
-                        </div>
-                        <p className="mt-2 text-sm text-muted-foreground">
-                            Centralize agent activity, project health, and system status in one dashboard.
-                        </p>
+        <div className="flex h-full flex-col overflow-auto bg-background">
+            <PageHeader
+                title="Mission Control"
+                titleAccessory={<VersionIndicator/>}
+                description="Centralize agent activity, project health, and system status in one dashboard."
+            >
+                <Button asChild size="sm">
+                    <Link to={getProjectsPath()}>View projects</Link>
+                </Button>
+                <Button asChild size="sm" variant="outline">
+                    <Link to={getSettingsPath()}>App settings</Link>
+                </Button>
+                <Button asChild size="sm" variant="outline">
+                    <Link to={getAgentSettingsPath('CODEX')}>Manage agents</Link>
+                </Button>
+                <div className="ml-auto flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                    <div className="flex items-center gap-2">
+                        <span>Time range</span>
+                        <Select
+                            value={effectiveTimeRangePreset}
+                            onValueChange={(value) => setTimeRangePreset(value as DashboardTimeRangePreset)}
+                        >
+                            <SelectTrigger size="sm">
+                                <SelectValue placeholder="Select range"/>
+                            </SelectTrigger>
+                            <SelectContent>
+                                {timeRangeOptions.map((option) => (
+                                    <SelectItem key={option.preset} value={option.preset}>
+                                        {option.label}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
                     </div>
-                    <div className="flex flex-wrap items-center gap-2">
-                        <Button asChild size="sm">
-                            <Link to={getProjectsPath()}>View projects</Link>
-                        </Button>
-                        <Button asChild size="sm" variant="outline">
-                            <Link to={getSettingsPath()}>App settings</Link>
-                        </Button>
-                        <Button asChild size="sm" variant="outline">
-                            <Link to={getAgentSettingsPath('CODEX')}>Manage agents</Link>
-                        </Button>
-                        <div className="ml-auto flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
-                            <div className="flex items-center gap-2">
-                                <span>Time range</span>
-                                <Select
-                                    value={effectiveTimeRangePreset}
-                                    onValueChange={(value) => setTimeRangePreset(value as DashboardTimeRangePreset)}
-                                >
-                                    <SelectTrigger size="sm">
-                                        <SelectValue placeholder="Select range"/>
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        {timeRangeOptions.map((option) => (
-                                            <SelectItem key={option.preset} value={option.preset}>
-                                                {option.label}
-                                            </SelectItem>
-                                        ))}
-                                    </SelectContent>
-                                </Select>
-                            </div>
-                            <span>
-                                {overview?.generatedAt || overview?.updatedAt
-                                    ? `Updated ${relativeTimeFromNow(overview.generatedAt ?? overview.updatedAt)}`
-                                    : dashboardQuery.isFetching
-                                        ? 'Updating…'
-                                        : ''}
-                            </span>
-                        </div>
-                    </div>
-                </header>
+                    <span>
+                        {overview?.generatedAt || overview?.updatedAt
+                            ? `Updated ${relativeTimeFromNow(overview.generatedAt ?? overview.updatedAt)}`
+                            : dashboardQuery.isFetching
+                                ? 'Updating…'
+                                : ''}
+                    </span>
+                </div>
+            </PageHeader>
+
+            <div className="w-full space-y-6 px-4 py-4 sm:px-6 sm:py-5 lg:px-8 lg:py-6">
 
                 {dashboardQuery.isError ? (
                     <SectionErrorBanner

--- a/client/src/pages/OnboardingPage.tsx
+++ b/client/src/pages/OnboardingPage.tsx
@@ -9,6 +9,7 @@ import {EditorStep} from './OnboardingPage/steps/EditorStep'
 import {GitStep} from './OnboardingPage/steps/GitStep'
 import {GithubDeviceFlowStep} from './OnboardingPage/steps/GithubDeviceFlowStep'
 import {SummaryStep} from './OnboardingPage/steps/SummaryStep'
+import {PageHeader} from '@/components/layout/PageHeader'
 
 export function OnboardingPage() {
     const {state, actions} = useOnboardingState()
@@ -97,23 +98,23 @@ export function OnboardingPage() {
             </aside>
 
             <div className="flex-1">
-                <header className="border-b border-border/60 bg-card/60 px-6 py-4 backdrop-blur">
-                    <div className="flex items-center justify-between">
-                        <div>
-                            <p className="text-xs uppercase tracking-wide text-muted-foreground">Onboarding</p>
-                            <h1 className="text-xl font-semibold text-foreground">{stepMeta.title}</h1>
-                            <p className="text-sm text-muted-foreground">{stepMeta.description}</p>
+                <PageHeader
+                    kicker="Onboarding"
+                    title={stepMeta.title}
+                    description={
+                        <>
+                            <p>{stepMeta.description}</p>
                             {state.onboardingCompleted ? (
-                                <p className="mt-1 text-xs text-muted-foreground">
+                                <p className="mt-1 text-xs">
                                     You previously completed onboarding. You can revisit steps and save updates here.
                                 </p>
                             ) : null}
-                        </div>
-                        <Badge variant="secondary">{currentStep + 1} / {stepCount}</Badge>
-                    </div>
-                </header>
+                        </>
+                    }
+                    actions={<Badge variant="secondary">{currentStep + 1} / {stepCount}</Badge>}
+                />
 
-                <main className="mx-auto w-full max-w-5xl px-6 py-8">
+                <main className="mx-auto w-full max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
                     <div className="rounded-xl border border-border/70 bg-card/70 p-6 shadow-sm backdrop-blur">
                         {stepId === 'welcome' ? (
                             <IntroStep appCredForm={state.appCredForm} setAppCredForm={actions.setAppCredForm}/>

--- a/client/src/pages/ProjectBoardPage.tsx
+++ b/client/src/pages/ProjectBoardPage.tsx
@@ -27,6 +27,7 @@ import { toast } from "@/components/ui/toast.tsx";
 import { eventBus } from "@/lib/events.ts";
 import { describeApiError } from "@/api/http";
 import { Loader2 } from "lucide-react";
+import { PageHeader } from "@/components/layout/PageHeader";
 
 export function ProjectBoardPage() {
     const { projectId } = useParams<{ projectId: string }>();
@@ -188,48 +189,50 @@ export function ProjectBoardPage() {
     }
 
     return (
-        <div className="flex h-full min-h-0 flex-col">
-            <div className="flex items-center justify-between px-4 py-4">
-                <div className="flex flex-wrap items-center gap-3">
-                    <img src={"/vite.svg"} className="h-6 w-6" />
-                    <div className="text-xl font-semibold">{project.name}</div>
-                    <VersionIndicator />
-                </div>
-                <div className="flex items-center gap-2">
-                    <Badge variant={connectionBadgeVariant}>
-                        {connectionLabel}
-                    </Badge>
-                    <Button
-                        variant="secondary"
-                        size="sm"
-                        onClick={() => setImportOpen(true)}
-                    >
-                        Import GitHub issues
-                    </Button>
-                </div>
-            </div>
+        <div className="flex h-full min-h-0 flex-col bg-background">
+            <PageHeader
+                title={project.name}
+                titleAccessory={<VersionIndicator />}
+                actions={
+                    <>
+                        <Badge variant={connectionBadgeVariant}>
+                            {connectionLabel}
+                        </Badge>
+                        <Button
+                            variant="secondary"
+                            size="sm"
+                            onClick={() => setImportOpen(true)}
+                        >
+                            Import GitHub issues
+                        </Button>
+                    </>
+                }
+            />
 
-            {enhancingCount > 0 && (
-                <div className="mx-4 mb-2 flex items-center gap-2 rounded-lg border border-border/60 bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
-                    <Loader2 className="size-4 animate-spin text-primary" />
-                    <span>
-                        {enhancingCount === 1
-                            ? "Enhancing 1 ticket in the background"
-                            : `Enhancing ${enhancingCount} tickets in the background`}
-                    </span>
-                </div>
-            )}
+            <div className="flex flex-1 min-h-0 flex-col px-4 py-4 sm:px-6 lg:px-8">
+                {enhancingCount > 0 && (
+                    <div className="mb-2 flex items-center gap-2 rounded-lg border border-border/60 bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+                        <Loader2 className="size-4 animate-spin text-primary" />
+                        <span>
+                            {enhancingCount === 1
+                                ? "Enhancing 1 ticket in the background"
+                                : `Enhancing ${enhancingCount} tickets in the background`}
+                        </span>
+                    </div>
+                )}
 
-            <div className="flex-1 min-h-0 px-4 pb-4">
-                <Board
-                    projectId={project.id}
-                    state={boardState}
-                    initialSelectedCardId={initialSelectedCardId}
-                    enhancementStatusByCardId={enhancementStatusByCardId}
-                    onCardEnhancementClick={(cardId) =>
-                        setEnhancementDialogCardId(cardId)
-                    }
-                    handlers={{
+                <div className="flex-1 min-h-0">
+                    <Board
+                        projectId={project.id}
+                        state={boardState}
+                        initialSelectedCardId={initialSelectedCardId}
+                        enhancementStatusByCardId={
+                            enhancementStatusByCardId
+                        }
+                        onCardEnhancementClick={(cardId) =>
+                            setEnhancementDialogCardId(cardId)
+                        }
+                        handlers={{
                         onCreateCard: async (
                             columnId,
                             values: CardFormValues,
@@ -431,7 +434,8 @@ export function ProjectBoardPage() {
                             });
                         },
                     }}
-                />
+                    />
+                </div>
             </div>
             <CardEnhancementDialog
                 open={Boolean(

--- a/client/test/PageHeader.test.tsx
+++ b/client/test/PageHeader.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import {describe, it, expect} from 'vitest'
+import {render, screen} from '@testing-library/react'
+
+import {PageHeader} from '@/components/layout/PageHeader'
+
+describe('PageHeader', () => {
+    it('renders a level-1 heading with the title', () => {
+        render(<PageHeader title="Hello"/>)
+
+        expect(
+            screen.getByRole('heading', {level: 1, name: 'Hello'}),
+        ).toBeTruthy()
+    })
+
+    it('renders optional description, kicker, actions, and footer content', () => {
+        render(
+            <PageHeader
+                kicker="Section"
+                title="Title"
+                description="Description"
+                actions={<button type="button">Action</button>}
+            >
+                <span>Footer content</span>
+            </PageHeader>,
+        )
+
+        expect(screen.getByText('Section')).toBeTruthy()
+        expect(screen.getByText('Description')).toBeTruthy()
+        expect(screen.getByRole('button', {name: 'Action'})).toBeTruthy()
+        expect(screen.getByText('Footer content')).toBeTruthy()
+    })
+
+    it('includes responsive padding classes and supports containerClassName', () => {
+        render(<PageHeader title="Responsive" containerClassName="max-w-5xl"/>)
+
+        const header = screen.getByTestId('page-header')
+        expect(header.getAttribute('data-component')).toBe('PageHeader')
+        expect(header.className).toContain('border-b')
+
+        const container = header.querySelector('div')
+        expect(container).toBeTruthy()
+        expect(container?.className).toContain('sm:px-6')
+        expect(container?.className).toContain('lg:px-8')
+        expect(container?.className).toContain('max-w-5xl')
+    })
+
+    it('matches the snapshot (visual regression)', () => {
+        const {container} = render(
+            <PageHeader
+                kicker="Kicker"
+                title="Snapshot Title"
+                description="Snapshot description"
+                actions={<button type="button">Action</button>}
+                containerClassName="max-w-5xl"
+            >
+                <span>Footer</span>
+            </PageHeader>,
+        )
+
+        expect(container.firstChild).toMatchSnapshot()
+    })
+})
+

--- a/client/test/PageHeaders.integration.test.tsx
+++ b/client/test/PageHeaders.integration.test.tsx
@@ -1,0 +1,407 @@
+import React from 'react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {cleanup, render, screen} from '@testing-library/react'
+import {MemoryRouter, Route, Routes} from 'react-router-dom'
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
+
+import {DashboardPage} from '@/pages/DashboardPage'
+import {ProjectBoardPage} from '@/pages/ProjectBoardPage'
+import {AppSettingsPage} from '@/pages/AppSettingsPage'
+import {AgentSettingsPage} from '@/pages/AgentSettingsPage'
+import {AttemptDetailPage} from '@/pages/AttemptDetailPage'
+import {OnboardingPage} from '@/pages/OnboardingPage'
+import {ProjectsLanding} from '@/components/projects/ProjectsLanding'
+
+const hooksMocks = vi.hoisted(() => ({
+    useDashboardOverview: vi.fn(),
+    useDashboardStream: vi.fn(),
+    useGithubAuthStatus: vi.fn(),
+    useAgents: vi.fn(),
+
+    useProject: vi.fn(),
+    useBoardState: vi.fn(),
+    useTicketEnhancementQueue: vi.fn(),
+    useCreateCard: vi.fn(),
+    useUpdateCard: vi.fn(),
+    useDeleteCard: vi.fn(),
+    useMoveCard: vi.fn(),
+
+    useAppSettings: vi.fn(),
+    useEditors: vi.fn(),
+    useGithubAppConfig: vi.fn(),
+    useSaveGithubAppConfig: vi.fn(),
+    useUpdateAppSettings: vi.fn(),
+
+    useAgentSchema: vi.fn(),
+    useAgentProfiles: vi.fn(),
+    useCreateAgentProfile: vi.fn(),
+    useUpdateAgentProfile: vi.fn(),
+    useDeleteAgentProfile: vi.fn(),
+
+    useAttempt: vi.fn(),
+    useAttemptLogs: vi.fn(),
+    useRelativeTimeFormatter: vi.fn(),
+}))
+
+vi.mock('@/hooks', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@/hooks')>()
+    return {
+        ...actual,
+        useDashboardOverview: hooksMocks.useDashboardOverview,
+        useDashboardStream: hooksMocks.useDashboardStream,
+        useGithubAuthStatus: hooksMocks.useGithubAuthStatus,
+        useAgents: hooksMocks.useAgents,
+
+        useProject: hooksMocks.useProject,
+        useBoardState: hooksMocks.useBoardState,
+        useTicketEnhancementQueue: hooksMocks.useTicketEnhancementQueue,
+        useCreateCard: hooksMocks.useCreateCard,
+        useUpdateCard: hooksMocks.useUpdateCard,
+        useDeleteCard: hooksMocks.useDeleteCard,
+        useMoveCard: hooksMocks.useMoveCard,
+
+        useAppSettings: hooksMocks.useAppSettings,
+        useEditors: hooksMocks.useEditors,
+        useGithubAppConfig: hooksMocks.useGithubAppConfig,
+        useSaveGithubAppConfig: hooksMocks.useSaveGithubAppConfig,
+        useUpdateAppSettings: hooksMocks.useUpdateAppSettings,
+
+        useAgentSchema: hooksMocks.useAgentSchema,
+        useAgentProfiles: hooksMocks.useAgentProfiles,
+        useCreateAgentProfile: hooksMocks.useCreateAgentProfile,
+        useUpdateAgentProfile: hooksMocks.useUpdateAgentProfile,
+        useDeleteAgentProfile: hooksMocks.useDeleteAgentProfile,
+
+        useAttempt: hooksMocks.useAttempt,
+        useAttemptLogs: hooksMocks.useAttemptLogs,
+        useRelativeTimeFormatter: hooksMocks.useRelativeTimeFormatter,
+    }
+})
+
+vi.mock('@/lib/ws', () => ({
+    useKanbanWS: () => ({connected: true, reconnecting: false, state: undefined}),
+}))
+
+vi.mock('@/components/kanban/Board', () => ({
+    Board: () => <div data-testid="board-stub"/>,
+}))
+
+vi.mock('@/components/kanban/card-dialogs/CardEnhancementDialog', () => ({
+    CardEnhancementDialog: () => null,
+}))
+
+vi.mock('@/components/github/ImportIssuesDialog', () => ({
+    ImportIssuesDialog: () => null,
+}))
+
+vi.mock('@/components/system/ConnectionLostDialog', () => ({
+    ConnectionLostDialog: () => null,
+}))
+
+vi.mock('@/pages/OnboardingPage/steps/IntroStep', () => ({IntroStep: () => <div/>}))
+vi.mock('@/pages/OnboardingPage/steps/SettingsStep', () => ({SettingsStep: () => <div/>}))
+vi.mock('@/pages/OnboardingPage/steps/EditorStep', () => ({EditorStep: () => <div/>}))
+vi.mock('@/pages/OnboardingPage/steps/GitStep', () => ({GitStep: () => <div/>}))
+vi.mock('@/pages/OnboardingPage/steps/GithubDeviceFlowStep', () => ({GithubDeviceFlowStep: () => <div/>}))
+vi.mock('@/pages/OnboardingPage/steps/SummaryStep', () => ({SummaryStep: () => <div/>}))
+
+vi.mock('@/pages/OnboardingPage/useOnboardingState', () => ({
+    STEP_ORDER: ['welcome', 'general', 'editor', 'github-app', 'github-connect', 'finish'],
+    STEP_META: {
+        welcome: {title: 'Welcome', description: 'A quick pass through preferences and GitHub.'},
+        general: {title: 'General preferences', description: 'Theme, language, telemetry, notifications.'},
+        editor: {title: 'Editor & Git defaults', description: 'Choose your editor and git identity.'},
+        'github-app': {title: 'GitHub templates & OAuth app', description: 'PR templates and your GitHub app credentials.'},
+        'github-connect': {title: 'Connect GitHub', description: 'Authorize KanbanAI via device flow.'},
+        finish: {title: 'All set', description: 'Review and enter the workspace.'},
+    },
+    useOnboardingState: () => ({
+        state: {
+            stepId: 'welcome',
+            stepIndex: 0,
+            stepCount: 6,
+            stepMeta: {title: 'Welcome', description: 'A quick pass through preferences and GitHub.'},
+            settingsForm: {
+                theme: 'system',
+                language: 'browser',
+                telemetryEnabled: false,
+                notificationsAgentCompletionSound: false,
+                notificationsDesktop: false,
+                autoStartAgentOnInProgress: false,
+                editorType: '',
+                gitUserName: '',
+                gitUserEmail: '',
+                branchTemplate: '',
+                ghPrTitleTemplate: '',
+                ghPrBodyTemplate: '',
+                ghAutolinkTickets: false,
+            },
+            appCredForm: null,
+            installedEditors: [],
+            connected: false,
+            connectedUsername: null,
+            onboardingCompleted: false,
+            githubConfigMissingId: false,
+            deviceState: null,
+            polling: false,
+            startingDevice: false,
+            isInitializing: false,
+            queryErrored: false,
+            queryErrorMessages: [],
+            onboardingStatusError: false,
+            completePending: false,
+            saveSettingsPending: false,
+            saveGithubAppPending: false,
+            githubAuthRefreshing: false,
+        },
+        actions: {
+            goNext: vi.fn(async () => {}),
+            goBack: vi.fn(async () => {}),
+            saveProgress: vi.fn(async () => {}),
+            handleDesktopToggle: vi.fn(async () => {}),
+            retryPrerequisites: vi.fn(),
+            refreshGithubStatus: vi.fn(),
+            startGithubConnect: vi.fn(async () => {}),
+            setSettingsForm: vi.fn(),
+            setAppCredForm: vi.fn(),
+        },
+    }),
+}))
+
+// Simplified Select implementation for predictable testing.
+vi.mock('@/components/ui/select', () => {
+    const SelectContext = React.createContext<{
+        value?: string
+        onChange?: (value: string) => void
+    }>({})
+
+    const Select = ({
+        value,
+        onValueChange,
+        children,
+    }: {
+        value?: string
+        onValueChange?: (value: string) => void
+        children: React.ReactNode
+    }) => (
+        <SelectContext.Provider value={{value, onChange: onValueChange}}>
+            <div data-slot="select">{children}</div>
+        </SelectContext.Provider>
+    )
+
+    const SelectTrigger = ({
+        children,
+        ...props
+    }: React.ComponentPropsWithoutRef<'button'>) => (
+        <button type="button" data-slot="select-trigger" {...props}>
+            {children}
+        </button>
+    )
+
+    const SelectValue = ({placeholder}: {placeholder?: string}) => (
+        <span>{placeholder}</span>
+    )
+
+    const SelectContent = ({children}: {children: React.ReactNode}) => (
+        <div data-slot="select-content">{children}</div>
+    )
+
+    const SelectItem = ({
+        value,
+        children,
+    }: {
+        value: string
+        children: React.ReactNode
+    }) => {
+        const ctx = React.useContext(SelectContext)
+        const selected = ctx.value === value
+        return (
+            <button
+                type="button"
+                role="option"
+                aria-selected={selected}
+                onClick={() => ctx.onChange?.(value)}
+            >
+                {children}
+            </button>
+        )
+    }
+
+    return {Select, SelectTrigger, SelectValue, SelectContent, SelectItem}
+})
+
+function renderWithQueryClient(ui: React.ReactElement) {
+    const client = new QueryClient({
+        defaultOptions: {
+            queries: {
+                retry: false,
+                gcTime: 0,
+                staleTime: 0,
+            },
+        },
+    })
+
+    return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>)
+}
+
+function expectUnifiedHeader(title: string) {
+    const header = screen.getByTestId('page-header')
+    expect(header.getAttribute('data-component')).toBe('PageHeader')
+    expect(header.className).toContain('border-b')
+    expect(header.className).toContain('bg-card/60')
+    expect(screen.getByRole('heading', {level: 1, name: title})).toBeTruthy()
+}
+
+describe('Page headers are unified across pages', () => {
+    beforeEach(() => {
+        cleanup()
+        vi.clearAllMocks()
+
+        hooksMocks.useDashboardOverview.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            isFetching: false,
+            isError: false,
+        })
+        hooksMocks.useDashboardStream.mockReturnValue({status: 'idle'})
+        hooksMocks.useGithubAuthStatus.mockReturnValue({
+            data: {status: 'valid', account: {username: 'dev'}},
+            isLoading: false,
+        })
+        hooksMocks.useAgents.mockReturnValue({
+            data: {agents: []},
+            isLoading: false,
+        })
+
+        hooksMocks.useProject.mockReturnValue({
+            data: {id: 'proj-1', name: 'Project Alpha', boardId: 'board-1'},
+            isLoading: false,
+            isError: false,
+            error: null,
+        })
+        hooksMocks.useBoardState.mockReturnValue({
+            data: {columns: {}, cards: {}},
+            isLoading: false,
+        })
+        hooksMocks.useTicketEnhancementQueue.mockReturnValue({
+            enhancements: {},
+            startEnhancementForNewCard: vi.fn(async () => {}),
+            startEnhancementForExistingCard: vi.fn(async () => {}),
+            clearEnhancement: vi.fn(),
+        })
+        hooksMocks.useCreateCard.mockReturnValue({mutateAsync: vi.fn(), isPending: false})
+        hooksMocks.useUpdateCard.mockReturnValue({mutateAsync: vi.fn(), isPending: false})
+        hooksMocks.useDeleteCard.mockReturnValue({mutateAsync: vi.fn(), isPending: false})
+        hooksMocks.useMoveCard.mockReturnValue({mutateAsync: vi.fn(), isPending: false})
+
+        hooksMocks.useAppSettings.mockReturnValue({data: null, isLoading: false})
+        hooksMocks.useEditors.mockReturnValue({data: []})
+        hooksMocks.useGithubAppConfig.mockReturnValue({data: undefined})
+        hooksMocks.useSaveGithubAppConfig.mockReturnValue({mutate: vi.fn(), isPending: false})
+        hooksMocks.useUpdateAppSettings.mockReturnValue({mutate: vi.fn(), isPending: false})
+
+        hooksMocks.useAgentSchema.mockReturnValue({data: undefined})
+        hooksMocks.useAgentProfiles.mockReturnValue({data: []})
+        hooksMocks.useCreateAgentProfile.mockReturnValue({mutate: vi.fn(), isPending: false})
+        hooksMocks.useUpdateAgentProfile.mockReturnValue({mutate: vi.fn(), isPending: false})
+        hooksMocks.useDeleteAgentProfile.mockReturnValue({mutate: vi.fn(), isPending: false})
+
+        hooksMocks.useAttempt.mockReturnValue({
+            data: {
+                id: '12345678abcdef',
+                status: 'running',
+                boardId: 'board-1',
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+                agent: 'CODEX',
+                cardId: 'card-1',
+            },
+            isLoading: false,
+            isError: false,
+        })
+        hooksMocks.useAttemptLogs.mockReturnValue({
+            data: [],
+            isLoading: false,
+            isError: false,
+        })
+        hooksMocks.useRelativeTimeFormatter.mockReturnValue(() => 'just now')
+    })
+
+    it('Projects page header is unified', () => {
+        render(
+            <ProjectsLanding
+                projects={[]}
+                onSelect={() => {}}
+                onCreate={() => {}}
+                onEdit={() => {}}
+                onDelete={() => {}}
+            />,
+        )
+
+        expectUnifiedHeader('Projects')
+    })
+
+    it('Dashboard page header is unified', () => {
+        renderWithQueryClient(
+            <MemoryRouter>
+                <DashboardPage/>
+            </MemoryRouter>,
+        )
+
+        expectUnifiedHeader('Mission Control')
+    })
+
+    it('Board page header is unified', () => {
+        renderWithQueryClient(
+            <MemoryRouter initialEntries={['/projects/proj-1']}>
+                <Routes>
+                    <Route path="/projects/:projectId" element={<ProjectBoardPage/>}/>
+                </Routes>
+            </MemoryRouter>,
+        )
+
+        expectUnifiedHeader('Project Alpha')
+    })
+
+    it('Settings page header is unified', () => {
+        render(<AppSettingsPage/>)
+
+        expectUnifiedHeader('Application Settings')
+    })
+
+    it('Agent settings page header is unified', () => {
+        renderWithQueryClient(
+            <MemoryRouter initialEntries={['/agents/CODEX']}>
+                <Routes>
+                    <Route path="/agents/:agentKey" element={<AgentSettingsPage/>}/>
+                </Routes>
+            </MemoryRouter>,
+        )
+
+        expectUnifiedHeader('CODEX Profiles')
+    })
+
+    it('Attempt detail page header is unified', () => {
+        render(
+            <MemoryRouter initialEntries={['/attempts/12345678abcdef']}>
+                <Routes>
+                    <Route path="/attempts/:attemptId" element={<AttemptDetailPage/>}/>
+                </Routes>
+            </MemoryRouter>,
+        )
+
+        expectUnifiedHeader('Attempt 12345678')
+    })
+
+    it('Onboarding page header is unified', () => {
+        render(
+            <MemoryRouter initialEntries={['/onboarding']}>
+                <Routes>
+                    <Route path="/onboarding" element={<OnboardingPage/>}/>
+                </Routes>
+            </MemoryRouter>,
+        )
+
+        expectUnifiedHeader('Welcome')
+    })
+})

--- a/client/test/__snapshots__/PageHeader.test.tsx.snap
+++ b/client/test/__snapshots__/PageHeader.test.tsx.snap
@@ -1,0 +1,57 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`PageHeader > matches the snapshot (visual regression) 1`] = `
+<header
+  class="border-b border-border/60 bg-card/60 backdrop-blur supports-[backdrop-filter]:bg-card/50"
+  data-component="PageHeader"
+  data-testid="page-header"
+>
+  <div
+    class="mx-auto flex w-full flex-col gap-3 px-4 py-4 sm:px-6 lg:px-8 max-w-5xl"
+  >
+    <div
+      class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between"
+    >
+      <div
+        class="min-w-0 space-y-1"
+      >
+        <p
+          class="text-xs font-medium uppercase tracking-wide text-muted-foreground"
+        >
+          Kicker
+        </p>
+        <div
+          class="flex flex-wrap items-center gap-3"
+        >
+          <h1
+            class="text-2xl font-semibold leading-tight text-foreground"
+          >
+            Snapshot Title
+          </h1>
+        </div>
+        <div
+          class="text-sm text-muted-foreground"
+        >
+          Snapshot description
+        </div>
+      </div>
+      <div
+        class="flex flex-wrap items-center gap-2"
+      >
+        <button
+          type="button"
+        >
+          Action
+        </button>
+      </div>
+    </div>
+    <div
+      class="flex flex-wrap items-center gap-2"
+    >
+      <span>
+        Footer
+      </span>
+    </div>
+  </div>
+</header>
+`;


### PR DESCRIPTION
## Summary
- Created a unified PageHeader component to standardize header layout and typography across all pages
- Refactored 6 pages to use the consistent PageHeader component
- Maintained existing functionality while improving code consistency and reducing duplication

## Changes Made
- Added `client/src/components/layout/PageHeader.tsx` - reusable component with consistent typography, spacing, and responsive design
- Updated `AgentSettingsPage.tsx`, `AppSettingsPage.tsx`, `AttemptDetailPage.tsx`, `DashboardPage.tsx`, `OnboardingPage.tsx`, and `ProjectBoardPage.tsx` to use PageHeader
- Added comprehensive test coverage for PageHeader component and integration tests
- Preserved all existing page-specific functionality like breadcrumbs, navigation, and action buttons

## Rationale
The previous implementation had inconsistent header layouts across pages with duplicated code for spacing, typography, and responsive behavior. The new PageHeader component provides:
- Consistent visual design across the application
- Reduced code duplication and maintenance overhead
- Centralized header logic for easier future updates
- Better separation of concerns between page content and header presentation